### PR TITLE
use after_commit hook to expire cached associations 

### DIFF
--- a/lib/active_model_cachers/cache_service_factory.rb
+++ b/lib/active_model_cachers/cache_service_factory.rb
@@ -6,7 +6,7 @@ module ActiveModelCachers
     @key_class_mapping = {}
 
     class << self
-      def create(reflect, cache_key, &query)
+      def create(cache_key, &query)
         @key_class_mapping[cache_key] ||= ->{
           klass = Class.new(CacheService)
           

--- a/lib/active_model_cachers/cache_service_factory.rb
+++ b/lib/active_model_cachers/cache_service_factory.rb
@@ -3,24 +3,28 @@ require 'active_model_cachers/cache_service'
 
 module ActiveModelCachers
   class CacheServiceFactory
+    @key_class_mapping = {}
+
     class << self
       def create(reflect, cache_key, &query)
-        klass = Class.new(CacheService)
+        @key_class_mapping[cache_key] ||= ->{
+          klass = Class.new(CacheService)
+          
+          class << klass
+            def instance(id)
+              hash = (RequestStore.store[self] ||= {})
+              return hash[id] ||= new(id)
+            end
 
-        class << klass
-          def instance(id)
-            hash = (RequestStore.store[self] ||= {})
-            return hash[id] ||= new(id)
+            def [](id)
+              instance(id)
+            end
           end
 
-          def [](id)
-            instance(id)
-          end
-        end
-
-        klass.send(:define_method, :cache_key){ "#{cache_key}_#{@id}" }
-        klass.send(:define_method, :get_without_cache){ query.call(@id) }
-        return klass
+          klass.send(:define_method, :cache_key){ "#{cache_key}_#{@id}" }
+          klass.send(:define_method, :get_without_cache){ query.call(@id) }
+          next klass
+        }[]
       end
     end
   end

--- a/test/active_model_cachers_test.rb
+++ b/test/active_model_cachers_test.rb
@@ -20,6 +20,20 @@ class ActiveModelCachersTest < Minitest::Test
     assert_cache('cacher_key_of_Profile_1' => profile)
   end
 
+  def test_cache_profile_after_update_nothing
+    profile = User.find_by(name: 'John1').profile
+    cacher = User.profile_cachers[profile.id]
+
+    assert_queries(1){ assert_equal 10, cacher.get.point }
+    assert_cache('cacher_key_of_Profile_1' => profile)
+
+    profile.save
+    assert_cache('cacher_key_of_Profile_1' => profile)
+
+    assert_queries(0){ assert_equal 10, cacher.get.point }
+    assert_cache('cacher_key_of_Profile_1' => profile)
+  end
+
   def test_cache_profile_after_update
     profile = User.find_by(name: 'John1').profile
     cacher = User.profile_cachers[profile.id]
@@ -48,6 +62,20 @@ class ActiveModelCachersTest < Minitest::Test
 
     assert_queries(0){ assert_equal 10, cacher.get }
     assert_cache('cacher_key_of_Profile_at_point_1' => 10)
+  end
+
+  def test_clean_profile_attribute_cache_after_update_nothing
+    profile = User.find_by(name: 'John2').profile
+    cacher = Profile.point_cachers[profile.id]
+
+    assert_queries(1){ assert_equal 30, cacher.get }
+    assert_cache('cacher_key_of_Profile_at_point_2' => 30)
+
+    profile.save
+    assert_cache('cacher_key_of_Profile_at_point_2' => 30)
+
+    assert_queries(0){ assert_equal 30, cacher.get }
+    assert_cache('cacher_key_of_Profile_at_point_2' => 30)
   end
 
   def test_clean_profile_attribute_cache_after_update

--- a/test/active_model_cachers_test.rb
+++ b/test/active_model_cachers_test.rb
@@ -9,7 +9,7 @@ class ActiveModelCachersTest < Minitest::Test
   # ----------------------------------------------------------------
   # ● association cache
   # ----------------------------------------------------------------
-  def test_cache_profile
+  def test_cache_has_one_association
     profile = User.find_by(name: 'John1').profile
     cacher = User.profile_cachers[profile.id]
 
@@ -20,7 +20,7 @@ class ActiveModelCachersTest < Minitest::Test
     assert_cache('cacher_key_of_Profile_1' => profile)
   end
 
-  def test_cache_profile_after_update_nothing
+  def test_cache_has_one_association_when_update_nothing
     profile = User.find_by(name: 'John1').profile
     cacher = User.profile_cachers[profile.id]
 
@@ -34,7 +34,7 @@ class ActiveModelCachersTest < Minitest::Test
     assert_cache('cacher_key_of_Profile_1' => profile)
   end
 
-  def test_cache_profile_after_update
+  def test_cache_has_one_association_when_update
     profile = User.find_by(name: 'John1').profile
     cacher = User.profile_cachers[profile.id]
 
@@ -50,10 +50,25 @@ class ActiveModelCachersTest < Minitest::Test
     profile.update_attributes(point: 10)
   end
 
+  def test_cache_has_one_association_when_destroy
+    profile = Profile.create(point: 13)
+    cacher = User.profile_cachers[profile.id]
+
+    assert_queries(1){ assert_equal 13, cacher.get.point }
+    assert_cache("cacher_key_of_Profile_#{profile.id}" => profile)
+
+    profile.destroy
+    assert_cache({})
+
+    assert_queries(1){ assert_nil cacher.get }
+    assert_cache({})
+  ensure
+    profile.destroy
+  end
   # ----------------------------------------------------------------
   # ● attribute cache
   # ----------------------------------------------------------------
-  def test_cache_profile_attribute
+  def test_cache_attribute
     profile = User.find_by(name: 'John1').profile
     cacher = Profile.point_cachers[profile.id]
 
@@ -64,7 +79,7 @@ class ActiveModelCachersTest < Minitest::Test
     assert_cache('cacher_key_of_Profile_at_point_1' => 10)
   end
 
-  def test_clean_profile_attribute_cache_after_update_nothing
+  def test_attribute_cache_when_update_nothing
     profile = User.find_by(name: 'John2').profile
     cacher = Profile.point_cachers[profile.id]
 
@@ -78,7 +93,7 @@ class ActiveModelCachersTest < Minitest::Test
     assert_cache('cacher_key_of_Profile_at_point_2' => 30)
   end
 
-  def test_clean_profile_attribute_cache_after_update
+  def test_attribute_cache_when_update
     profile = User.find_by(name: 'John2').profile
     cacher = Profile.point_cachers[profile.id]
 
@@ -94,7 +109,7 @@ class ActiveModelCachersTest < Minitest::Test
     profile.update_attributes(point: 30)
   end
 
-  def test_clean_profile_attribute_cache_after_destroy
+  def test_attribute_cache_when_destroy
     profile = Profile.create(point: 30)
     cacher = Profile.point_cachers[profile.id]
 

--- a/test/active_model_cachers_test.rb
+++ b/test/active_model_cachers_test.rb
@@ -14,10 +14,10 @@ class ActiveModelCachersTest < Minitest::Test
     cacher = User.profile_cachers[profile.id]
 
     assert_queries(1){ assert_equal 10, cacher.get.point }
-    assert_cache('cacher_key_of_User_at_profile_1' => profile)
+    assert_cache('cacher_key_of_Profile_1' => profile)
 
     assert_queries(0){ assert_equal 10, cacher.get.point }
-    assert_cache('cacher_key_of_User_at_profile_1' => profile)
+    assert_cache('cacher_key_of_Profile_1' => profile)
   end
 
   def test_cache_profile_after_update
@@ -25,15 +25,15 @@ class ActiveModelCachersTest < Minitest::Test
     cacher = User.profile_cachers[profile.id]
 
     assert_queries(1){ assert_equal 10, cacher.get.point }
-    assert_cache('cacher_key_of_User_at_profile_1' => profile)
+    assert_cache('cacher_key_of_Profile_1' => profile)
 
     profile.update_attributes(point: 12)
     assert_cache({})
 
-    assert_queries(0){ assert_equal 12, cacher.get.point }
-    assert_cache('cacher_key_of_User_at_profile_1' => profile)
+    assert_queries(1){ assert_equal 12, cacher.get.point }
+    assert_cache('cacher_key_of_Profile_1' => profile)
   ensure 
-    profile.update_attributes(point: 12)
+    profile.update_attributes(point: 10)
   end
 
   # ----------------------------------------------------------------

--- a/test/active_model_cachers_test.rb
+++ b/test/active_model_cachers_test.rb
@@ -9,7 +9,7 @@ class ActiveModelCachersTest < Minitest::Test
   # ----------------------------------------------------------------
   # ● association cache
   # ----------------------------------------------------------------
-  def test_cache_has_one_association
+  def test_has_one_cache
     profile = User.find_by(name: 'John1').profile
     cacher = User.profile_cachers[profile.id]
 
@@ -20,7 +20,7 @@ class ActiveModelCachersTest < Minitest::Test
     assert_cache('cacher_key_of_Profile_1' => profile)
   end
 
-  def test_cache_has_one_association_when_update_nothing
+  def test_has_one_cache_when_update_nothing
     profile = User.find_by(name: 'John1').profile
     cacher = User.profile_cachers[profile.id]
 
@@ -34,7 +34,7 @@ class ActiveModelCachersTest < Minitest::Test
     assert_cache('cacher_key_of_Profile_1' => profile)
   end
 
-  def test_cache_has_one_association_when_update
+  def test_has_one_cache_when_update
     profile = User.find_by(name: 'John1').profile
     cacher = User.profile_cachers[profile.id]
 
@@ -50,7 +50,7 @@ class ActiveModelCachersTest < Minitest::Test
     profile.update_attributes(point: 10)
   end
 
-  def test_cache_has_one_association_when_destroy
+  def test_has_one_cache_when_destroy
     profile = Profile.create(point: 13)
     cacher = User.profile_cachers[profile.id]
 
@@ -65,10 +65,28 @@ class ActiveModelCachersTest < Minitest::Test
   ensure
     profile.destroy
   end
+
+  def test_has_one_cache_when_destroyed_by_dependent_delete
+    profile = Profile.create(point: 17)
+    user = User.create(profile: profile)
+    cacher = User.profile_cachers[profile.id]
+
+    assert_queries(1){ assert_equal 17, cacher.get.point }
+    assert_cache("cacher_key_of_Profile_#{profile.id}" => profile)
+
+    user.destroy
+    assert_cache({})
+
+    assert_queries(1){ assert_nil cacher.get }
+    assert_cache({})
+  ensure
+    user.destroy
+  end
+
   # ----------------------------------------------------------------
   # ● attribute cache
   # ----------------------------------------------------------------
-  def test_cache_attribute
+  def test_attribute_cache
     profile = User.find_by(name: 'John1').profile
     cacher = Profile.point_cachers[profile.id]
 
@@ -121,5 +139,7 @@ class ActiveModelCachersTest < Minitest::Test
 
     assert_queries(1){ assert_nil cacher.get }
     assert_cache({})
+  ensure
+    profile.destroy
   end
 end

--- a/test/seeds.rb
+++ b/test/seeds.rb
@@ -34,6 +34,7 @@ end
 class Profile < ActiveRecord::Base
   belongs_to :user
 
+  cache_self
   cache_at :point
 end
 

--- a/test/seeds.rb
+++ b/test/seeds.rb
@@ -22,7 +22,7 @@ end
 
 class User < ActiveRecord::Base
   has_many :posts
-  has_one :profile
+  has_one :profile, dependent: :delete
 
   cache_at :profile
 end


### PR DESCRIPTION
use `cache_self` to make Profile cachable. 
then use cache_at :profile to cache `user.profile`.
```rb
class User < ActiveRecord::Base
  has_one :profile
  cache_at :profile
end

class Profile < ActiveRecord::Base
  cache_self
end
```