### PR TITLE
Safer cache mechanism: Prevent cache from being left over if someone forget to writing `cache_self`

### DIFF
--- a/lib/active_model_cachers.rb
+++ b/lib/active_model_cachers.rb
@@ -2,6 +2,7 @@ require 'active_model_cachers/version'
 require 'active_model_cachers/config'
 require 'active_model_cachers/cache_service_factory'
 require 'active_model_cachers/cacher'
+require 'active_model_cachers/hook_dependencies'
 require 'active_record'
 require 'active_record/relation'
 
@@ -39,6 +40,9 @@ class << ActiveRecord::Base
           target = association(column).load_target if destroyed? 
           service_klass.instance(target.id).clean_cache if target
         }
+      end
+      ActiveSupport::Dependencies.onload(reflect.class_name) do
+        after_commit ->{ service_klass.instance(id).clean_cache if previous_changes.present? || destroyed? }
       end
     else
       after_commit ->{ service_klass.instance(id).clean_cache if previous_changes.key?(column) || destroyed? }

--- a/lib/active_model_cachers/hook_dependencies.rb
+++ b/lib/active_model_cachers/hook_dependencies.rb
@@ -8,7 +8,7 @@ module ActiveSupport #:nodoc:
       end
 
       def clear_load_hooks
-        self.load_hooks = Hash.new([])
+        self.load_hooks = Hash.new{|h, k| h[k] = [] }
       end
 
       alias_method :new_constants_in_without_onload_hook, :new_constants_in if not method_defined?(:new_constants_in_without_onload_hook)

--- a/lib/active_model_cachers/hook_dependencies.rb
+++ b/lib/active_model_cachers/hook_dependencies.rb
@@ -1,0 +1,25 @@
+require 'active_support/dependencies'
+
+module ActiveSupport #:nodoc:
+  module Dependencies #:nodoc:
+    class << self
+      def onload(const_name, &blk)
+        load_hooks[const_name.to_sym].push(blk)
+      end
+
+      def clear_load_hooks
+        self.load_hooks = Hash.new([])
+      end
+
+      alias_method :new_constants_in_without_onload_hook, :new_constants_in if not method_defined?(:new_constants_in_without_onload_hook)
+      def new_constants_in(*descs, &block)
+        new_constants = new_constants_in_without_onload_hook(*descs, &block)
+        new_constants.each{|s| Dependencies.load_hooks[s].each{|hook| s.constantize.instance_exec(&hook) } }
+        return new_constants
+      end
+    end
+
+    mattr_accessor :load_hooks
+    clear_load_hooks
+  end
+end

--- a/lib/active_model_cachers/hook_dependencies.rb
+++ b/lib/active_model_cachers/hook_dependencies.rb
@@ -4,7 +4,7 @@ module ActiveSupport #:nodoc:
   module Dependencies #:nodoc:
     class << self
       def onload(const_name, &blk)
-        load_hooks[const_name.to_sym].push(blk)
+        load_hooks[const_name].push(blk)
       end
 
       def clear_load_hooks
@@ -14,7 +14,7 @@ module ActiveSupport #:nodoc:
       alias_method :new_constants_in_without_onload_hook, :new_constants_in if not method_defined?(:new_constants_in_without_onload_hook)
       def new_constants_in(*descs, &block)
         new_constants = new_constants_in_without_onload_hook(*descs, &block)
-        new_constants.each{|s| Dependencies.load_hooks[s].each{|hook| s.constantize.instance_exec(&hook) } }
+        new_constants.each{|s| load_hooks[s].each{|hook| s.constantize.instance_exec(&hook) } }
         return new_constants
       end
     end

--- a/test/active_model_cachers_test.rb
+++ b/test/active_model_cachers_test.rb
@@ -47,6 +47,21 @@ class ActiveModelCachersTest < Minitest::Test
     profile.update_attributes(point: 10)
   end
 
+  def test_when_target_association_doesnt_cache_self
+    contact = User.find_by(name: 'John1').contact
+
+    assert_queries(1){ assert_equal '12345', User.cacher_at(contact.id).contact.phone }
+    assert_cache('cacher_key_of_Contact_1' => contact)
+
+    contact.update_attributes(phone: '12346')
+    assert_cache({})
+
+    assert_queries(1){ assert_equal '12346', User.cacher_at(contact.id).contact.phone }
+    assert_cache('cacher_key_of_Contact_1' => contact)
+  ensure 
+    contact.update_attributes(phone: '12345')
+  end
+
   def test_has_one_cache_when_destroy
     profile = Profile.create(point: 13)
 

--- a/test/models/contact.rb
+++ b/test/models/contact.rb
@@ -1,0 +1,3 @@
+class Contact < ActiveRecord::Base
+  belongs_to :user
+end

--- a/test/models/post.rb
+++ b/test/models/post.rb
@@ -1,0 +1,3 @@
+class Post < ActiveRecord::Base
+  belongs_to :user
+end

--- a/test/models/profile.rb
+++ b/test/models/profile.rb
@@ -1,0 +1,6 @@
+class Profile < ActiveRecord::Base
+  belongs_to :user
+
+  cache_self
+  cache_at :point
+end

--- a/test/models/user.rb
+++ b/test/models/user.rb
@@ -1,0 +1,8 @@
+class User < ActiveRecord::Base
+  has_many :posts
+  has_one :profile, dependent: :delete
+  has_one :contact, dependent: :delete
+
+  cache_at :profile
+  cache_at :contact
+end

--- a/test/seeds.rb
+++ b/test/seeds.rb
@@ -25,29 +25,7 @@ ActiveRecord::Schema.define do
   end
 end
 
-class User < ActiveRecord::Base
-  has_many :posts
-  has_one :profile, dependent: :delete
-  has_one :contact, dependent: :delete
-
-  cache_at :profile
-  cache_at :contact
-end
-
-class Post < ActiveRecord::Base
-  belongs_to :user
-end
-
-class Profile < ActiveRecord::Base
-  belongs_to :user
-
-  cache_self
-  cache_at :point
-end
-
-class Contact < ActiveRecord::Base
-  belongs_to :user
-end
+ActiveSupport::Dependencies.autoload_paths << File.expand_path('../models/', __FILE__)
 
 users = User.create([
   {:name => 'John1', :email => 'john1@example.com', :profile => Profile.create(point: 10), :contact => Contact.create(phone: '12345')},

--- a/test/seeds.rb
+++ b/test/seeds.rb
@@ -18,13 +18,20 @@ ActiveRecord::Schema.define do
     t.integer :user_id
     t.integer :point
   end
+
+  create_table :contacts, :force => true do |t|
+    t.integer :user_id
+    t.string :phone
+  end
 end
 
 class User < ActiveRecord::Base
   has_many :posts
   has_one :profile, dependent: :delete
+  has_one :contact, dependent: :delete
 
   cache_at :profile
+  cache_at :contact
 end
 
 class Post < ActiveRecord::Base
@@ -38,8 +45,12 @@ class Profile < ActiveRecord::Base
   cache_at :point
 end
 
+class Contact < ActiveRecord::Base
+  belongs_to :user
+end
+
 users = User.create([
-  {:name => 'John1', :email => 'john1@example.com', :profile => Profile.create(point: 10)},
+  {:name => 'John1', :email => 'john1@example.com', :profile => Profile.create(point: 10), :contact => Contact.create(phone: '12345')},
   {:name => 'John2', :email => 'john2@example.com', :profile => Profile.create(point: 30)},
   {:name => 'John3', :email => 'john3@example.com', :profile => Profile.create(point: 50)},
   {:name => 'John4', :email => 'john4@example.com', :profile => Profile.create(point: 70)},


### PR DESCRIPTION
In the following example
```rb
class User < ActiveRecord::Base
  has_one :profile
  cache_at :profile
end
```
You must add `cache_self` to the classes where will be used by the cachers.
If you forget to do so, the cache on profile will not be cleaned when profile is updated or destroyed.
```rb
class Profile < ActiveRecord::Base
  cache_self
end
```

It doesn't have to do it in this PR.
