### PR TITLE
 allow developer to specify whether the cache should expire

### DIFF
--- a/lib/active_model_cachers.rb
+++ b/lib/active_model_cachers.rb
@@ -32,7 +32,7 @@ module ActiveModelCachers::ActiveRecord
       expire_by = reflect.class_name
     else              # Cache attributes
       with_id = true
-      expire_by = "#{self}.#{column}"
+      expire_by = "#{self}##{column}"
     end
     define_callback_for_cleaning_cache(service_klass, expire_by, with_id: with_id, on: on)
   end
@@ -64,7 +64,7 @@ module ActiveModelCachers::ActiveRecord
   private
 
   def define_callback_for_cleaning_cache(service_klass, expire_by, with_id: true, on: nil)
-    class_name, column = expire_by.split('.')
+    class_name, column = expire_by.split('#', 2)
     define_callback_proc = proc do
       on_delete{|id| service_klass.clean_at(with_id ? id : nil) }
       if column == nil

--- a/lib/active_model_cachers/cache_service_factory.rb
+++ b/lib/active_model_cachers/cache_service_factory.rb
@@ -36,6 +36,10 @@ module ActiveModelCachers
               return hash[id] ||= new(id)
             end
 
+            def clean_at(id)
+              instance(id).clean_cache
+            end
+
             def [](id)
               instance(id)
             end

--- a/lib/active_model_cachers/cache_service_factory.rb
+++ b/lib/active_model_cachers/cache_service_factory.rb
@@ -7,17 +7,15 @@ module ActiveModelCachers
 
     class << self
       def create_for_active_model(klass, column, &query)
+        reflect = klass.reflect_on_association(column)
         case
-        # ● Cache self
-        when column == nil
+        when column == nil # Cache self
           query ||= ->(id){ klass.find_by(id: id) } 
           cache_key = get_cache_key(klass, column)
-        # ● Cache associations
-        when (reflect = klass.reflect_on_association(column))
+        when reflect       # Cache associations
           query ||= ->(id){ get_klass_from_reflect(reflect).find_by(id: id) }
           cache_key = get_cache_key(reflect.class_name, nil)
-        # ● Cache attributes
-        else
+        else               # Cache attributes
           query ||= ->(id){ klass.where(id: id).limit(1).pluck(column).first }
           cache_key = get_cache_key(klass, column)
         end

--- a/test/cache_active_user_count_test.rb
+++ b/test/cache_active_user_count_test.rb
@@ -1,0 +1,113 @@
+require 'base_test'
+
+class CacheActiveUserCountTest < BaseTest
+  def test_basic_usage
+    assert_queries(1){ assert_equal 2, User.cacher.active_count }
+    assert_cache('active_model_cachers_User_at_active_count' => 2)
+
+    assert_queries(0){ assert_equal 2, User.cacher.active_count }
+    assert_cache('active_model_cachers_User_at_active_count' => 2)
+  end
+
+  def test_create
+    user = nil
+    
+    assert_queries(1){ assert_equal 2, User.cacher.active_count }
+    assert_queries(0){ assert_equal 2, User.cacher.active_count }
+    assert_cache('active_model_cachers_User_at_active_count' => 2)
+
+    user = User.create(id: -1, last_login_at: Time.now)
+    assert_cache({})
+
+    assert_queries(1){ assert_equal 3, User.cacher.active_count }
+    assert_queries(0){ assert_equal 3, User.cacher.active_count }
+    assert_cache('active_model_cachers_User_at_active_count' => 3)
+  ensure
+    user.destroy if user
+  end
+
+  def test_update_nothing
+    user = User.find_by(name: 'John2')
+
+    assert_queries(1){ assert_equal 2, User.cacher.active_count }
+    assert_queries(0){ assert_equal 2, User.cacher.active_count }
+    assert_cache('active_model_cachers_User_at_active_count' => 2)
+
+    user.save
+    assert_cache('active_model_cachers_User_at_active_count' => 2)
+
+    assert_queries(0){ assert_equal 2, User.cacher.active_count }
+    assert_cache('active_model_cachers_User_at_active_count' => 2)
+  end
+
+  def test_update_unrelated_column
+    user = User.find_by(name: 'John4')
+
+    assert_queries(1){ assert_equal 2, User.cacher.active_count }
+    assert_queries(0){ assert_equal 2, User.cacher.active_count }
+    assert_cache('active_model_cachers_User_at_active_count' => 2)
+
+    user.update_attributes(name: '??')
+    assert_cache('active_model_cachers_User_at_active_count' => 2)
+
+    assert_queries(0){ assert_equal 2, User.cacher.active_count }
+    assert_cache('active_model_cachers_User_at_active_count' => 2)
+  ensure
+    user.update_attributes(name: 'John4')
+  end
+
+  def test_update
+    user = User.find_by(name: 'John4')
+
+    assert_queries(1){ assert_equal 2, User.cacher.active_count }
+    assert_queries(0){ assert_equal 2, User.cacher.active_count }
+    assert_cache('active_model_cachers_User_at_active_count' => 2)
+
+    user.update_attributes(last_login_at: Time.now)
+    assert_cache({})
+
+    assert_queries(1){ assert_equal 3, User.cacher.active_count }
+    assert_queries(0){ assert_equal 3, User.cacher.active_count }
+    assert_cache('active_model_cachers_User_at_active_count' => 3)
+  ensure
+    user.update_attributes(last_login_at: nil)
+  end
+
+  def test_destroy
+    user = User.create(last_login_at: Time.now)
+
+    assert_queries(1){ assert_equal 3, User.cacher.active_count }
+    assert_queries(0){ assert_equal 3, User.cacher.active_count }
+    assert_cache("active_model_cachers_User_at_active_count" => 3)
+
+    user.destroy
+    assert_cache({})
+
+    assert_queries(1){ assert_equal 2, User.cacher.active_count }
+    assert_queries(0){ assert_equal 2, User.cacher.active_count }
+    assert_cache('active_model_cachers_User_at_active_count' => 2)
+  ensure
+    user.destroy
+  end
+
+  def test_delete
+    user = User.create(last_login_at: Time.now)
+
+    assert_queries(1){ assert_equal 3, User.cacher.active_count }
+    assert_queries(0){ assert_equal 3, User.cacher.active_count }
+    assert_cache("active_model_cachers_User_at_active_count" => 3)
+
+    user.delete
+    assert_cache({})
+
+    assert_queries(1){ assert_equal 2, User.cacher.active_count }
+    assert_queries(0){ assert_equal 2, User.cacher.active_count }
+    assert_cache('active_model_cachers_User_at_active_count' => 2)
+  ensure
+    user.destroy
+  end
+
+  def test_destroyed_by_dependent_delete
+    # TODO
+  end
+end

--- a/test/lib/models/user.rb
+++ b/test/lib/models/user.rb
@@ -5,7 +5,7 @@ class User < ActiveRecord::Base
 
   cache_at :profile
   cache_at :contact
-  cache_at :count, ->{ User.count }, expire_by: 'User'
+  cache_at :count, ->{ User.count }, expire_by: 'User', on: [:create, :destroy]
 
   cache_at :active_count, ->{ User.where('last_login_at > ?', 7.days.ago).count }, expire_by: 'User.last_login_at'
 end

--- a/test/lib/models/user.rb
+++ b/test/lib/models/user.rb
@@ -7,5 +7,5 @@ class User < ActiveRecord::Base
   cache_at :contact
   cache_at :count, ->{ User.count }, expire_by: 'User'
 
-  cache_at :active_count, ->{ User.where('last_login_at > ?', 7.days.ago).count }, expire_by: 'User'
+  cache_at :active_count, ->{ User.where('last_login_at > ?', 7.days.ago).count }, expire_by: 'User.last_login_at'
 end

--- a/test/lib/models/user.rb
+++ b/test/lib/models/user.rb
@@ -6,4 +6,6 @@ class User < ActiveRecord::Base
   cache_at :profile
   cache_at :contact
   cache_at :count, ->{ User.count }, expire_by: 'User'
+
+  cache_at :active_count, ->{ User.where('last_login_at > ?', 7.days.ago).count }, expire_by: 'User'
 end

--- a/test/lib/models/user.rb
+++ b/test/lib/models/user.rb
@@ -7,5 +7,5 @@ class User < ActiveRecord::Base
   cache_at :contact
 
   cache_at :count, ->{ User.count }, expire_by: 'User', on: [:create, :destroy]
-  cache_at :active_count, ->{ User.where('last_login_at > ?', 7.days.ago).count }, expire_by: 'User.last_login_at'
+  cache_at :active_count, ->{ User.where('last_login_at > ?', 7.days.ago).count }, expire_by: 'User#last_login_at'
 end

--- a/test/lib/models/user.rb
+++ b/test/lib/models/user.rb
@@ -5,7 +5,7 @@ class User < ActiveRecord::Base
 
   cache_at :profile
   cache_at :contact
-  cache_at :count, ->{ User.count }, expire_by: 'User', on: [:create, :destroy]
 
+  cache_at :count, ->{ User.count }, expire_by: 'User', on: [:create, :destroy]
   cache_at :active_count, ->{ User.where('last_login_at > ?', 7.days.ago).count }, expire_by: 'User.last_login_at'
 end

--- a/test/lib/seeds.rb
+++ b/test/lib/seeds.rb
@@ -8,6 +8,7 @@ ActiveRecord::Schema.define do
     t.string :name
     t.string :email
     t.text :serialized_attribute
+    t.datetime :last_login_at
   end
 
   create_table :posts, :force => true do |t|
@@ -29,10 +30,27 @@ end
 ActiveSupport::Dependencies.autoload_paths << File.expand_path('../models/', __FILE__)
 
 users = User.create([
-  {:name => 'John1', :email => 'john1@example.com', :profile => Profile.create(point: 10), :contact => Contact.create(phone: '12345')},
-  {:name => 'John2', :email => 'john2@example.com', :profile => Profile.create(point: 30)},
-  {:name => 'John3', :email => 'john3@example.com', :profile => Profile.create(point: 50)},
-  {:name => 'John4', :email => 'john4@example.com', :profile => Profile.create(point: 70)},
+  {
+    :name          => 'John1', 
+    :email         => 'john1@example.com', 
+    :profile       => Profile.create(point: 10), 
+    :contact       => Contact.create(phone: '12345'),
+    :last_login_at => Time.now,
+  }, {
+    :name          => 'John2', 
+    :email         => 'john2@example.com', 
+    :profile       => Profile.create(point: 30),
+    :last_login_at => Time.now,
+  }, {
+    :name          => 'John3', 
+    :email         => 'john3@example.com', 
+    :profile       => Profile.create(point: 50),
+    :last_login_at => 1.month.ago,
+  }, {
+    :name          => 'John4', 
+    :email         => 'john4@example.com', 
+    :profile       => Profile.create(point: 70),
+  },
 ])
 
 Post.create([


### PR DESCRIPTION
You could specify the cache objects to only expire on create or on destroy but not expire on update. 
By using this syntax:`on: [:create, :destroy]`.
```rb
class User < ActiveRecord::Base
  cache_at :count, ->{ User.count }, expire_by: 'User', on: [:create, :destroy]
end
```

You could specify the cache objects to only expire on specific column updated.
By using this syntax: `expire_by: 'User#last_login_at'`.
```rb
class User < ActiveRecord::Base
  cache_at :active_count, ->{ User.active_count }, expire_by: 'User#last_login_at'
end
```

