### PR TITLE
cache on falsy result

### DIFF
--- a/lib/active_model_cachers/cache_service.rb
+++ b/lib/active_model_cachers/cache_service.rb
@@ -1,3 +1,6 @@
+require 'active_model_cachers/nil_object'
+require 'active_model_cachers/false_object'
+
 module ActiveModelCachers
   class CacheService
     def initialize(id)
@@ -6,6 +9,7 @@ module ActiveModelCachers
 
     def get
       @cached_data ||= get_from_cache
+      return cache_to_raw_data(@cached_data)
     end
 
     def clean_cache
@@ -23,8 +27,22 @@ module ActiveModelCachers
       fail 'not implement'
     end
 
+    def raw_to_cache_data(raw)
+      return NilObject if raw == nil
+      return FalseObject if raw == false
+      return raw
+    end
+
+    def cache_to_raw_data(cached_data)
+      return nil if cached_data == NilObject
+      return false if cached_data == FalseObject
+      return cached_data
+    end
+
     def get_from_cache
-      ActiveModelCachers.config.store.fetch(cache_key, expires_in: 30.minutes){ get_without_cache }
+      ActiveModelCachers.config.store.fetch(cache_key, expires_in: 30.minutes) do 
+        raw_to_cache_data(get_without_cache)
+      end
     end
   end
 end

--- a/lib/active_model_cachers/false_object.rb
+++ b/lib/active_model_cachers/false_object.rb
@@ -1,0 +1,4 @@
+module ActiveModelCachers
+  class FalseObject
+  end
+end

--- a/lib/active_model_cachers/nil_object.rb
+++ b/lib/active_model_cachers/nil_object.rb
@@ -1,0 +1,4 @@
+module ActiveModelCachers
+  class NilObject
+  end
+end

--- a/test/cache_at_attribute_test.rb
+++ b/test/cache_at_attribute_test.rb
@@ -16,8 +16,8 @@ class CacheAtAttributeTest < BaseTest
     profile = nil
 
     assert_queries(1){ assert_nil Profile.cacher_at(-1).point }
-    assert_queries(1){ assert_nil Profile.cacher_at(-1).point } # FIXME: should be 0 query
-    assert_cache({})
+    assert_queries(0){ assert_nil Profile.cacher_at(-1).point }
+    assert_cache('active_model_cachers_Profile_at_point_-1' => ActiveModelCachers::NilObject)
 
     profile = Profile.create(id: -1, point: 3)
     assert_cache({})
@@ -71,8 +71,8 @@ class CacheAtAttributeTest < BaseTest
     assert_cache({})
 
     assert_queries(1){ assert_nil Profile.cacher_at(profile.id).point }
-    assert_queries(1){ assert_nil Profile.cacher_at(profile.id).point } # FIXME: should be 0 query
-    assert_cache({})
+    assert_queries(0){ assert_nil Profile.cacher_at(profile.id).point }
+    assert_cache("active_model_cachers_Profile_at_point_#{profile.id}" => ActiveModelCachers::NilObject)
   ensure
     profile.destroy
   end
@@ -88,8 +88,8 @@ class CacheAtAttributeTest < BaseTest
     assert_cache({})
 
     assert_queries(1){ assert_nil Profile.cacher_at(profile.id).point }
-    assert_queries(1){ assert_nil Profile.cacher_at(profile.id).point } # FIXME: should be 0 query
-    assert_cache({})
+    assert_queries(0){ assert_nil Profile.cacher_at(profile.id).point }
+    assert_cache("active_model_cachers_Profile_at_point_#{profile.id}" => ActiveModelCachers::NilObject)
   ensure
     profile.delete
   end
@@ -106,8 +106,8 @@ class CacheAtAttributeTest < BaseTest
     assert_cache({})
 
     assert_queries(1){ assert_nil Profile.cacher_at(profile.id).point }
-    assert_queries(1){ assert_nil Profile.cacher_at(profile.id).point } # FIXME: should be 0 query
-    assert_cache({})
+    assert_queries(0){ assert_nil Profile.cacher_at(profile.id).point }
+    assert_cache("active_model_cachers_Profile_at_point_#{profile.id}" => ActiveModelCachers::NilObject)
   ensure
     user.destroy
   end

--- a/test/cache_at_has_one_test.rb
+++ b/test/cache_at_has_one_test.rb
@@ -16,8 +16,8 @@ class CacheAtHasOneTest < BaseTest
     profile = nil
 
     assert_queries(1){ assert_nil User.cacher_at(-1).profile }
-    assert_queries(1){ assert_nil User.cacher_at(-1).profile } # FIXME: should be 0 query
-    assert_cache({})
+    assert_queries(0){ assert_nil User.cacher_at(-1).profile }
+    assert_cache('active_model_cachers_Profile_-1' => ActiveModelCachers::NilObject)
 
     profile = Profile.create(id: -1, point: 3)
     assert_cache({})
@@ -93,8 +93,8 @@ class CacheAtHasOneTest < BaseTest
     assert_cache({})
 
     assert_queries(1){ assert_nil User.cacher_at(profile.id).profile }
-    assert_queries(1){ assert_nil User.cacher_at(profile.id).profile } # FIXME: should be 0 query
-    assert_cache({})
+    assert_queries(0){ assert_nil User.cacher_at(profile.id).profile }
+    assert_cache("active_model_cachers_Profile_#{profile.id}" => ActiveModelCachers::NilObject)
   ensure
     profile.destroy
   end
@@ -110,8 +110,8 @@ class CacheAtHasOneTest < BaseTest
     assert_cache({})
 
     assert_queries(1){ assert_nil User.cacher_at(profile.id).profile }
-    assert_queries(1){ assert_nil User.cacher_at(profile.id).profile } # FIXME: should be 0 query
-    assert_cache({})
+    assert_queries(0){ assert_nil User.cacher_at(profile.id).profile }
+    assert_cache("active_model_cachers_Profile_#{profile.id}" => ActiveModelCachers::NilObject)
   ensure
     profile.delete
   end
@@ -128,8 +128,8 @@ class CacheAtHasOneTest < BaseTest
     assert_cache({})
 
     assert_queries(1){ assert_nil User.cacher_at(profile.id).profile }
-    assert_queries(1){ assert_nil User.cacher_at(profile.id).profile } # FIXME: should be 0 query
-    assert_cache({})
+    assert_queries(0){ assert_nil User.cacher_at(profile.id).profile }
+    assert_cache("active_model_cachers_Profile_#{profile.id}" => ActiveModelCachers::NilObject)
   ensure
     user.destroy
   end

--- a/test/cache_bool_data_test.rb
+++ b/test/cache_bool_data_test.rb
@@ -1,6 +1,6 @@
 require 'base_test'
 
-class CacheFalseDataTest < BaseTest
+class CacheBoolDataTest < BaseTest
   def test_basic_usage
     user = User.find_by(name: 'John1')
 

--- a/test/cache_false_data_test.rb
+++ b/test/cache_false_data_test.rb
@@ -1,0 +1,20 @@
+require 'base_test'
+
+class CacheFalseDataTest < BaseTest
+  def test_basic_usage
+    user = User.find_by(name: 'John1')
+
+    assert_queries(1){ assert_equal true, User.cacher_at(user.id).has_post? }
+    assert_queries(0){ assert_equal true, User.cacher_at(user.id).has_post? }
+    assert_cache('active_model_cachers_User_at_has_post?_1' => true)
+  end
+
+  def test_false_data_should_be_cached
+    user = User.find_by(name: 'John4')
+
+    # false data should be cached, no more query is called if it is cached.
+    assert_queries(1){ assert_equal false, User.cacher_at(user.id).has_post? }
+    assert_queries(0){ assert_equal false, User.cacher_at(user.id).has_post? }
+    assert_cache('active_model_cachers_User_at_has_post?_4' => ActiveModelCachers::FalseObject)
+  end
+end

--- a/test/cache_self_test.rb
+++ b/test/cache_self_test.rb
@@ -16,8 +16,8 @@ class CacheSelfTest < BaseTest
     profile = nil
 
     assert_queries(1){ assert_nil Profile.cacher_at(-1).self }
-    assert_queries(1){ assert_nil Profile.cacher_at(-1).self } # FIXME: should be 0 query
-    assert_cache({})
+    assert_queries(0){ assert_nil Profile.cacher_at(-1).self }
+    assert_cache('active_model_cachers_Profile_-1' => ActiveModelCachers::NilObject)
 
     profile = Profile.create(id: -1, point: 3)
     assert_cache({})
@@ -71,8 +71,8 @@ class CacheSelfTest < BaseTest
     assert_cache({})
 
     assert_queries(1){ assert_nil User.cacher_at(profile.id).profile }
-    assert_queries(1){ assert_nil User.cacher_at(profile.id).profile } # FIXME: should be 0 query
-    assert_cache({})
+    assert_queries(0){ assert_nil User.cacher_at(profile.id).profile }
+    assert_cache("active_model_cachers_Profile_#{profile.id}" => ActiveModelCachers::NilObject)
   ensure
     profile.destroy
   end
@@ -88,8 +88,8 @@ class CacheSelfTest < BaseTest
     assert_cache({})
 
     assert_queries(1){ assert_nil Profile.cacher_at(profile.id).self }
-    assert_queries(1){ assert_nil Profile.cacher_at(profile.id).self } # FIXME: should be 0 query
-    assert_cache({})
+    assert_queries(0){ assert_nil Profile.cacher_at(profile.id).self }
+    assert_cache("active_model_cachers_Profile_#{profile.id}" => ActiveModelCachers::NilObject)
   ensure
     profile.delete
   end
@@ -106,8 +106,8 @@ class CacheSelfTest < BaseTest
     assert_cache({})
 
     assert_queries(1){ assert_nil Profile.cacher_at(profile.id).self }
-    assert_queries(1){ assert_nil Profile.cacher_at(profile.id).self } # FIXME: should be 0 query
-    assert_cache({})
+    assert_queries(0){ assert_nil Profile.cacher_at(profile.id).self }
+    assert_cache("active_model_cachers_Profile_#{profile.id}" => ActiveModelCachers::NilObject)
   ensure
     user.destroy
   end
@@ -127,8 +127,8 @@ class CacheSelfTest < BaseTest
     assert_cache({})
 
     assert_queries(1){ assert_nil Difficulty.cacher_at(difficulty.id).self }
-    assert_queries(1){ assert_nil Difficulty.cacher_at(difficulty.id).self } # FIXME: should be 0 query
-    assert_cache({})
+    assert_queries(0){ assert_nil Difficulty.cacher_at(difficulty.id).self }
+    assert_cache("active_model_cachers_Difficulty_#{difficulty.id}" => ActiveModelCachers::NilObject)
   ensure
     difficulty.delete
   end
@@ -149,8 +149,8 @@ class CacheSelfTest < BaseTest
 
     assert_queries(0){ assert_equal 7, Profile.cacher_at(profile.id).self.point }
     assert_queries(1){ assert_nil Difficulty.cacher_at(difficulty.id).self }
-    assert_queries(1){ assert_nil Difficulty.cacher_at(difficulty.id).self } # FIXME: should be 0 query
-    assert_cache('active_model_cachers_Profile_-1' => profile)
+    assert_queries(0){ assert_nil Difficulty.cacher_at(difficulty.id).self }
+    assert_cache('active_model_cachers_Profile_-1' => profile, 'active_model_cachers_Difficulty_-1' => ActiveModelCachers::NilObject)
   ensure
     profile.delete
     difficulty.delete

--- a/test/lib/models/user.rb
+++ b/test/lib/models/user.rb
@@ -3,9 +3,12 @@ class User < ActiveRecord::Base
   has_one :profile, dependent: :delete
   has_one :contact, dependent: :delete
 
+  scope :active, ->{ where('last_login_at > ?', 7.days.ago) }
+
   cache_at :profile
   cache_at :contact
 
   cache_at :count, ->{ User.count }, expire_by: 'User', on: [:create, :destroy]
-  cache_at :active_count, ->{ User.where('last_login_at > ?', 7.days.ago).count }, expire_by: 'User#last_login_at'
+  cache_at :active_count, ->{ User.active.count }, expire_by: 'User#last_login_at'
+  cache_at :has_post?, ->(id){ Post.where(user_id: id).exists? } # TODO: posts.exists?
 end


### PR DESCRIPTION
In previous implement, falsy value like `nil` or `false` will not be cached because it use `||=`.