### PR TITLE
Fix id problem by specify foreign_key manually

### DIFF
--- a/lib/active_model_cachers.rb
+++ b/lib/active_model_cachers.rb
@@ -20,11 +20,15 @@ module ActiveModelCachers::ActiveRecord
     cache_at(nil, expire_by: self.to_s)
   end
 
-  def cache_at(column, query = nil, expire_by: nil, on: nil)
+  def cache_at(column, query = nil, expire_by: nil, on: nil, foreign_key: :id)
     service_klass, with_id = ActiveModelCachers::CacheServiceFactory.create_for_active_model(self, column, &query)
+
     expire_by ||= reflect_on_association(column).try(:class_name) || "#{self}##{column}"
     class_name, column = expire_by.split('#', 2)
-    define_callback_for_cleaning_cache(class_name, column, on: on){|id| service_klass.clean_at(with_id ? id : nil) }
+
+    define_callback_for_cleaning_cache(class_name, column, foreign_key, on: on) do |id| 
+      service_klass.clean_at(with_id ? id : nil)
+    end
   end
 
   if Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('4')
@@ -53,10 +57,16 @@ module ActiveModelCachers::ActiveRecord
 
   private
 
-  def define_callback_for_cleaning_cache(class_name, column, on: nil, &clean)
+  def define_callback_for_cleaning_cache(class_name, column, foreign_key, on: nil, &clean)
     ActiveSupport::Dependencies.onload(class_name) do
-      on_delete{|id| clean.call(id) }
-      after_commit ->{ clean.call(id) if destroyed? || (column ? previous_changes.key?(column) : previous_changes.present?) }, on: on
+      on_delete do |id|
+        clean.call(id)
+      end
+
+      after_commit ->{
+        changed = column ? previous_changes.key?(column) : previous_changes.present?
+        clean.call(send(foreign_key)) if changed || destroyed?
+      }, on: on
     end
   end
 end

--- a/lib/active_model_cachers.rb
+++ b/lib/active_model_cachers.rb
@@ -17,7 +17,7 @@ end
 
 module ActiveModelCachers::ActiveRecord
   def cache_self
-    cache_at(nil, nil, expire_by: self.to_s)
+    cache_at(nil, expire_by: self.to_s)
   end
 
   def cache_at(column, query = nil, expire_by: nil, on: nil)

--- a/lib/active_model_cachers.rb
+++ b/lib/active_model_cachers.rb
@@ -22,13 +22,9 @@ module ActiveModelCachers::ActiveRecord
 
   def cache_at(column, query = nil, expire_by: nil, on: nil)
     service_klass, with_id = ActiveModelCachers::CacheServiceFactory.create_for_active_model(self, column, &query)
-    
-    expire_by ||= ->{
-      reflect = reflect_on_association(column)
-      next reflect ? reflect.class_name : "#{self}##{column}"
-    }[]
-
-    define_callback_for_cleaning_cache(expire_by, on: on){|id| service_klass.clean_at(with_id ? id : nil) }
+    expire_by ||= reflect_on_association(column).try(:class_name) || "#{self}##{column}"
+    class_name, column = expire_by.split('#', 2)
+    define_callback_for_cleaning_cache(class_name, column, on: on){|id| service_klass.clean_at(with_id ? id : nil) }
   end
 
   if Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('4')
@@ -57,17 +53,11 @@ module ActiveModelCachers::ActiveRecord
 
   private
 
-  def define_callback_for_cleaning_cache(expire_by, on: nil, &clean)
-    class_name, column = expire_by.split('#', 2)
-    define_callback_proc = proc do
+  def define_callback_for_cleaning_cache(class_name, column, on: nil, &clean)
+    ActiveSupport::Dependencies.onload(class_name) do
       on_delete{|id| clean.call(id) }
-      if column == nil
-        after_commit ->{ clean.call(id) if previous_changes.present? || destroyed? }, on: on
-      else
-        after_commit ->{ clean.call(id) if previous_changes.key?(column) || destroyed? }, on: on
-      end
+      after_commit ->{ clean.call(id) if destroyed? || (column ? previous_changes.key?(column) : previous_changes.present?) }, on: on
     end
-    ActiveSupport::Dependencies.onload(class_name, &define_callback_proc)
   end
 end
 

--- a/lib/active_model_cachers/cache_service_factory.rb
+++ b/lib/active_model_cachers/cache_service_factory.rb
@@ -21,7 +21,7 @@ module ActiveModelCachers
         end
         service_klass = create(cache_key, &query)
         ActiveModelCachers::Cacher.define_cacher_at(klass, column || :self, service_klass)
-        return service_klass
+        return service_klass, (query.parameters.size == 1)
       end
 
       def create(cache_key, &query)

--- a/test/cache_bool_data_test.rb
+++ b/test/cache_bool_data_test.rb
@@ -17,4 +17,21 @@ class CacheBoolDataTest < BaseTest
     assert_queries(0){ assert_equal false, User.cacher_at(user.id).has_post? }
     assert_cache('active_model_cachers_User_at_has_post?_4' => ActiveModelCachers::FalseObject)
   end
+
+  def test_create
+    user = User.find_by(name: 'John4')
+
+    assert_queries(1){ assert_equal false, User.cacher_at(user.id).has_post? }
+    assert_queries(0){ assert_equal false, User.cacher_at(user.id).has_post? }
+    assert_cache('active_model_cachers_User_at_has_post?_4' => ActiveModelCachers::FalseObject)
+
+    post = Post.create(user: user)
+    assert_cache({})
+
+    assert_queries(1){ assert_equal true, User.cacher_at(user.id).has_post? }
+    assert_queries(0){ assert_equal true, User.cacher_at(user.id).has_post? }
+    assert_cache('active_model_cachers_User_at_has_post?_4' => true)
+  ensure
+    post.destroy if post
+  end
 end

--- a/test/lib/models/user.rb
+++ b/test/lib/models/user.rb
@@ -10,5 +10,5 @@ class User < ActiveRecord::Base
 
   cache_at :count, ->{ User.count }, expire_by: 'User', on: [:create, :destroy]
   cache_at :active_count, ->{ User.active.count }, expire_by: 'User#last_login_at'
-  cache_at :has_post?, ->(id){ Post.where(user_id: id).exists? } # TODO: posts.exists?
+  cache_at :has_post?, ->(id){ Post.where(user_id: id).exists? }, expire_by: 'Post#user_id' # TODO: posts.exists?
 end

--- a/test/lib/models/user.rb
+++ b/test/lib/models/user.rb
@@ -10,5 +10,5 @@ class User < ActiveRecord::Base
 
   cache_at :count, ->{ User.count }, expire_by: 'User', on: [:create, :destroy]
   cache_at :active_count, ->{ User.active.count }, expire_by: 'User#last_login_at'
-  cache_at :has_post?, ->(id){ Post.where(user_id: id).exists? }, expire_by: 'Post#user_id' # TODO: posts.exists?
+  cache_at :has_post?, ->(id){ Post.where(user_id: id).exists? }, expire_by: 'Post#user_id', foreign_key: :user_id # TODO: posts.exists?
 end


### PR DESCRIPTION
EX: 
```rb
class User < ActiveRecord::Base
  cache_at :has_post?, ->(id){ Post.where(user_id: id).exists? }, expire_by: 'Post#user_id'
end
```
The result is cached by user.id, but when a post is changed, it doesn't know which column (in this case: `user_id`) to use to clean the cache.

So this PR add `foreign_key` options to specify it. 


Still trying to find a more elegant way to get all the information it needs to know.....

