### PR TITLE
Fix that cache not cleaned if foreign_key is not `id` and calling `mode.delete`

### DIFF
--- a/lib/active_model_cachers/active_record/extension.rb
+++ b/lib/active_model_cachers/active_record/extension.rb
@@ -25,15 +25,20 @@ module ActiveModelCachers
       def get_column_value_from_id(id, column)
         return id if column == :id
         model = cacher_at(id).peek_self if has_cacher?
-        return model[column] if model
+        return model.send(column) if model
         return where(id: id).limit(1).pluck(column).first
       end
 
       def define_callback_for_cleaning_cache(class_name, column, foreign_key, on: nil, &clean)
         ActiveSupport::Dependencies.onload(class_name) do
-          on_delete do |id|
-            id = get_column_value_from_id(id, foreign_key)
-            clean.call(id)
+          ids = []
+          before_delete do |id|
+            ids << get_column_value_from_id(id, foreign_key)
+          end
+
+          after_delete do
+            ids.each{|s| clean.call(s) }
+            ids = []
           end
 
           after_commit ->{

--- a/lib/active_model_cachers/active_record/extension.rb
+++ b/lib/active_model_cachers/active_record/extension.rb
@@ -21,6 +21,7 @@ module ActiveModelCachers
       def define_callback_for_cleaning_cache(class_name, column, foreign_key, on: nil, &clean)
         ActiveSupport::Dependencies.onload(class_name) do
           on_delete do |id|
+            id = where(id: id).limit(1).pluck(foreign_key).first if foreign_key != :id
             clean.call(id)
           end
 

--- a/lib/active_model_cachers/cache_service.rb
+++ b/lib/active_model_cachers/cache_service.rb
@@ -8,6 +8,11 @@ module ActiveModelCachers
     end
 
     def get
+      @cached_data ||= fetch_from_cache
+      return cache_to_raw_data(@cached_data)
+    end
+
+    def peek
       @cached_data ||= get_from_cache
       return cache_to_raw_data(@cached_data)
     end
@@ -40,6 +45,10 @@ module ActiveModelCachers
     end
 
     def get_from_cache
+      ActiveModelCachers.config.store.read(cache_key)
+    end
+
+    def fetch_from_cache
       ActiveModelCachers.config.store.fetch(cache_key, expires_in: 30.minutes) do
         raw_to_cache_data(get_without_cache)
       end

--- a/lib/active_model_cachers/cache_service_factory.rb
+++ b/lib/active_model_cachers/cache_service_factory.rb
@@ -6,6 +6,10 @@ module ActiveModelCachers
     @key_class_mapping = {}
 
     class << self
+      def has_cacher?(klass, column)
+        return (@key_class_mapping[get_cache_key(klass, column)] != nil)
+      end
+
       def create_for_active_model(klass, column, &query)
         reflect = klass.reflect_on_association(column)
         case
@@ -36,10 +40,6 @@ module ActiveModelCachers
 
             def clean_at(id)
               instance(id).clean_cache
-            end
-
-            def [](id)
-              instance(id)
             end
           end
 

--- a/lib/active_model_cachers/cacher.rb
+++ b/lib/active_model_cachers/cacher.rb
@@ -3,10 +3,15 @@ module ActiveModelCachers
     @defined_map = {}
 
     class << self
+      def has_cacher?(klass)
+        return (@defined_map[klass] != nil)
+      end
+
       def define_cacher_at(klass, method, service_klass)
         cacher_klass = (@defined_map[klass] ||= create_cacher_klass_at(klass))
         cacher_klass.attributes << method
         cacher_klass.send(:define_method, method){ service_klass.instance(@id).get }
+        cacher_klass.send(:define_method, "peek_#{method}"){ service_klass.instance(@id).peek }
       end
 
       private

--- a/lib/active_model_cachers/cacher.rb
+++ b/lib/active_model_cachers/cacher.rb
@@ -3,10 +3,6 @@ module ActiveModelCachers
     @defined_map = {}
 
     class << self
-      def has_cacher?(klass)
-        return (@defined_map[klass] != nil)
-      end
-
       def define_cacher_at(klass, method, service_klass)
         cacher_klass = (@defined_map[klass] ||= create_cacher_klass_at(klass))
         cacher_klass.attributes << method

--- a/lib/active_model_cachers/hook_dependencies.rb
+++ b/lib/active_model_cachers/hook_dependencies.rb
@@ -14,10 +14,6 @@ module ActiveModelCachers::HookDepdenencies
     @load_hooks ||= Hash.new{|h, k| h[k] = [] }
   end
 
-  def clear_load_hooks
-    @load_hooks = Hash.new{|h, k| h[k] = [] }
-  end
-
   def new_constants_in(*)
     new_constants = super.each{|s| load_hooks[s].each{|hook| s.constantize.instance_exec(&hook) } }
     return new_constants

--- a/lib/active_model_cachers/hook_on_model_delete.rb
+++ b/lib/active_model_cachers/hook_on_model_delete.rb
@@ -1,21 +1,27 @@
 require 'active_record'
 
 module ActiveModelCachers::HookOnModelDelete
-  def on_delete(&callback)
-    delete_hooks << callback
+  def before_delete(&callback)
+    before_delete_hooks << callback
   end
 
-  def delete_hooks
-    @delete_hooks ||= []
+  def after_delete(&callback)
+    after_delete_hooks << callback
   end
 
-  def clear_delete_hooks
-    @delete_hooks = []
+  def before_delete_hooks
+    @before_delete_hooks ||= []
+  end
+
+  def after_delete_hooks
+    @after_delete_hooks ||= []
   end
 
   def delete(id)
-    delete_hooks.each{|s| s.call(id) }
-    super
+    before_delete_hooks.each{|s| s.call(id) }
+    result = super
+    after_delete_hooks.each{|s| s.call(id) }
+    return result
   end
 end
 

--- a/test/cache_bool_data_test.rb
+++ b/test/cache_bool_data_test.rb
@@ -34,4 +34,42 @@ class CacheBoolDataTest < BaseTest
   ensure
     post.destroy if post
   end
+
+  def test_destroy
+    user = User.create(name: 'John5')
+    post = Post.create(user: user)
+
+    assert_queries(1){ assert_equal true, User.cacher_at(user.id).has_post? }
+    assert_queries(0){ assert_equal true, User.cacher_at(user.id).has_post? }
+    assert_cache("active_model_cachers_User_at_has_post?_#{user.id}" => true)
+
+    post.destroy
+    assert_cache({})
+
+    assert_queries(1){ assert_equal false, User.cacher_at(user.id).has_post? }
+    assert_queries(0){ assert_equal false, User.cacher_at(user.id).has_post? }
+    assert_cache("active_model_cachers_User_at_has_post?_#{user.id}" => ActiveModelCachers::FalseObject)
+  ensure
+    user.delete
+    post.delete
+  end
+
+  def test_delete
+    user = User.create(name: 'John5')
+    post = Post.create(user: user)
+
+    assert_queries(1){ assert_equal true, User.cacher_at(user.id).has_post? }
+    assert_queries(0){ assert_equal true, User.cacher_at(user.id).has_post? }
+    assert_cache("active_model_cachers_User_at_has_post?_#{user.id}" => true)
+
+    post.delete
+    assert_cache({})
+
+    assert_queries(1){ assert_equal false, User.cacher_at(user.id).has_post? }
+    assert_queries(0){ assert_equal false, User.cacher_at(user.id).has_post? }
+    assert_cache("active_model_cachers_User_at_has_post?_#{user.id}" => ActiveModelCachers::FalseObject)
+  ensure
+    user.delete
+    post.delete
+  end
 end

--- a/test/cache_bool_data_test.rb
+++ b/test/cache_bool_data_test.rb
@@ -69,8 +69,8 @@ class CacheBoolDataTest < BaseTest
     assert_queries(1){ post.delete } # one delete and one from cache
     assert_cache({})
 
-    assert_queries(1){ assert_equal false, User.cacher_at(user.id).has_post2? }
-    assert_queries(0){ assert_equal false, User.cacher_at(user.id).has_post2? }
+    assert_queries(1){ assert_equal false, User.cacher_at(user.id).has_post? }
+    assert_queries(0){ assert_equal false, User.cacher_at(user.id).has_post? }
     assert_cache("active_model_cachers_User_at_has_post?_#{user.id}" => ActiveModelCachers::FalseObject)
   ensure
     user.delete

--- a/test/cache_bool_data_test.rb
+++ b/test/cache_bool_data_test.rb
@@ -81,16 +81,16 @@ class CacheBoolDataTest < BaseTest
     user = User.create(name: 'John5')
     post = PostWithoutCache.create(user: user)
 
-    assert_queries(1){ assert_equal true, User.cacher_at(user.id).has_post2? }
-    assert_queries(0){ assert_equal true, User.cacher_at(user.id).has_post2? }
-    assert_cache("active_model_cachers_User_at_has_post2?_#{user.id}" => true)
+    assert_queries(1){ assert_equal true, User.cacher_at(user.id).has_post_without_cache? }
+    assert_queries(0){ assert_equal true, User.cacher_at(user.id).has_post_without_cache? }
+    assert_cache("active_model_cachers_User_at_has_post_without_cache?_#{user.id}" => true)
 
     assert_queries(2){ post.delete } # one delete and one select
     assert_cache({})
 
-    assert_queries(1){ assert_equal false, User.cacher_at(user.id).has_post2? }
-    assert_queries(0){ assert_equal false, User.cacher_at(user.id).has_post2? }
-    assert_cache("active_model_cachers_User_at_has_post2?_#{user.id}" => ActiveModelCachers::FalseObject)
+    assert_queries(1){ assert_equal false, User.cacher_at(user.id).has_post_without_cache? }
+    assert_queries(0){ assert_equal false, User.cacher_at(user.id).has_post_without_cache? }
+    assert_cache("active_model_cachers_User_at_has_post_without_cache?_#{user.id}" => ActiveModelCachers::FalseObject)
   ensure
     user.delete
     post.delete

--- a/test/cache_bool_data_test.rb
+++ b/test/cache_bool_data_test.rb
@@ -18,6 +18,9 @@ class CacheBoolDataTest < BaseTest
     assert_cache('active_model_cachers_User_at_has_post?_4' => ActiveModelCachers::FalseObject)
   end
 
+  # ----------------------------------------------------------------
+  # ● Create
+  # ----------------------------------------------------------------
   def test_create
     user = User.find_by(name: 'John4')
 
@@ -35,6 +38,9 @@ class CacheBoolDataTest < BaseTest
     post.destroy if post
   end
 
+  # ----------------------------------------------------------------
+  # ● Destroy
+  # ----------------------------------------------------------------
   def test_destroy
     user = User.create(name: 'John5')
     post = Post.create(user: user)
@@ -54,7 +60,44 @@ class CacheBoolDataTest < BaseTest
     post.delete
   end
 
-  def test_delete_target_with_cache_self
+  # ----------------------------------------------------------------
+  # ● Delete
+  # ----------------------------------------------------------------
+  def test_delete_target
+    user = User.create(name: 'John5')
+    post = PostWithoutCache.create(user: user)
+
+    assert_queries(1){ assert_equal true, User.cacher_at(user.id).has_post_without_cache? }
+    assert_queries(0){ assert_equal true, User.cacher_at(user.id).has_post_without_cache? }
+    assert_cache("active_model_cachers_User_at_has_post_without_cache?_#{user.id}" => true)
+
+    assert_queries(2){ post.delete } # select post.user_id and then delete post.
+    assert_cache({})
+
+    assert_queries(1){ assert_equal false, User.cacher_at(user.id).has_post_without_cache? }
+    assert_queries(0){ assert_equal false, User.cacher_at(user.id).has_post_without_cache? }
+    assert_cache("active_model_cachers_User_at_has_post_without_cache?_#{user.id}" => ActiveModelCachers::FalseObject)
+  ensure
+    user.delete
+    post.delete
+  end
+
+  def test_delete_target_with_cache_self_but_not_cached
+    user = User.create(name: 'John5')
+    post = Post.create(user: user)
+
+    assert_queries(1){ assert_equal true, User.cacher_at(user.id).has_post? }
+    assert_queries(0){ assert_equal true, User.cacher_at(user.id).has_post? }
+    assert_cache("active_model_cachers_User_at_has_post?_#{user.id}" => true)
+
+    assert_queries(2){ post.delete } # select post.user_id and then delete post.
+    assert_cache({})
+  ensure
+    user.delete
+    post.delete
+  end
+
+  def test_delete_target_with_cache_self_and_cached
     user = User.create(name: 'John5')
     post = Post.create(user: user)
 
@@ -66,31 +109,8 @@ class CacheBoolDataTest < BaseTest
     assert_queries(0){ assert_equal post, Post.cacher_at(post.id).self }
     assert_cache("active_model_cachers_User_at_has_post?_#{user.id}" => true, "active_model_cachers_Post_#{post.id}" => post)
 
-    assert_queries(1){ post.delete } # one delete and one from cache
+    assert_queries(1){ post.delete } # select post.user_id from cache and then delete post.
     assert_cache({})
-
-    assert_queries(1){ assert_equal false, User.cacher_at(user.id).has_post? }
-    assert_queries(0){ assert_equal false, User.cacher_at(user.id).has_post? }
-    assert_cache("active_model_cachers_User_at_has_post?_#{user.id}" => ActiveModelCachers::FalseObject)
-  ensure
-    user.delete
-    post.delete
-  end
-
-  def test_delete_target_without_cache_self
-    user = User.create(name: 'John5')
-    post = PostWithoutCache.create(user: user)
-
-    assert_queries(1){ assert_equal true, User.cacher_at(user.id).has_post_without_cache? }
-    assert_queries(0){ assert_equal true, User.cacher_at(user.id).has_post_without_cache? }
-    assert_cache("active_model_cachers_User_at_has_post_without_cache?_#{user.id}" => true)
-
-    assert_queries(2){ post.delete } # one delete and one select
-    assert_cache({})
-
-    assert_queries(1){ assert_equal false, User.cacher_at(user.id).has_post_without_cache? }
-    assert_queries(0){ assert_equal false, User.cacher_at(user.id).has_post_without_cache? }
-    assert_cache("active_model_cachers_User_at_has_post_without_cache?_#{user.id}" => ActiveModelCachers::FalseObject)
   ensure
     user.delete
     post.delete

--- a/test/cache_bool_data_test.rb
+++ b/test/cache_bool_data_test.rb
@@ -62,7 +62,7 @@ class CacheBoolDataTest < BaseTest
     assert_queries(0){ assert_equal true, User.cacher_at(user.id).has_post? }
     assert_cache("active_model_cachers_User_at_has_post?_#{user.id}" => true)
 
-    post.delete
+    assert_queries(2){ post.delete } # one delete and one select
     assert_cache({})
 
     assert_queries(1){ assert_equal false, User.cacher_at(user.id).has_post? }

--- a/test/cache_self_test.rb
+++ b/test/cache_self_test.rb
@@ -117,7 +117,7 @@ class CacheSelfTest < BaseTest
 
     # make sure Difficulty only have cache_self, and doesn't cache by other models by something like cache_at :difficulty
     assert_equal [:self], Difficulty.cacher.class.attributes
-    assert_equal 1, Difficulty.delete_hooks.size
+    assert_equal 1, Difficulty.before_delete_hooks.size
 
     assert_queries(1){ assert_equal 4, Difficulty.cacher_at(difficulty.id).self.level }
     assert_queries(0){ assert_equal 4, Difficulty.cacher_at(difficulty.id).self.level }

--- a/test/lib/models/post.rb
+++ b/test/lib/models/post.rb
@@ -1,3 +1,5 @@
 class Post < ActiveRecord::Base
   belongs_to :user
+
+  cache_self
 end

--- a/test/lib/models/post_without_cache.rb
+++ b/test/lib/models/post_without_cache.rb
@@ -1,0 +1,3 @@
+class PostWithoutCache < ActiveRecord::Base
+  belongs_to :user
+end

--- a/test/lib/models/user.rb
+++ b/test/lib/models/user.rb
@@ -1,6 +1,6 @@
 class User < ActiveRecord::Base
   has_many :posts
-  has_many :post_without_caches, class_name: 'Post'
+  has_many :posts_without_cache, class_name: 'PostWithoutCache'
   has_one :profile, dependent: :delete
   has_one :contact, dependent: :delete
 

--- a/test/lib/models/user.rb
+++ b/test/lib/models/user.rb
@@ -12,5 +12,5 @@ class User < ActiveRecord::Base
   cache_at :count, ->{ User.count }, expire_by: 'User', on: [:create, :destroy]
   cache_at :active_count, ->{ User.active.count }, expire_by: 'User#last_login_at'
   cache_at :has_post?, ->(id){ Post.where(user_id: id).exists? }, expire_by: 'Post#user_id', foreign_key: :user_id # TODO: posts.exists?
-  cache_at :has_post2?, ->(id){ PostWithoutCache.where(user_id: id).exists? }, expire_by: 'PostWithoutCache#user_id', foreign_key: :user_id
+  cache_at :has_post_without_cache?, ->(id){ PostWithoutCache.where(user_id: id).exists? }, expire_by: 'PostWithoutCache#user_id', foreign_key: :user_id
 end

--- a/test/lib/models/user.rb
+++ b/test/lib/models/user.rb
@@ -1,5 +1,6 @@
 class User < ActiveRecord::Base
   has_many :posts
+  has_many :post_without_caches, class_name: 'Post'
   has_one :profile, dependent: :delete
   has_one :contact, dependent: :delete
 
@@ -11,4 +12,5 @@ class User < ActiveRecord::Base
   cache_at :count, ->{ User.count }, expire_by: 'User', on: [:create, :destroy]
   cache_at :active_count, ->{ User.active.count }, expire_by: 'User#last_login_at'
   cache_at :has_post?, ->(id){ Post.where(user_id: id).exists? }, expire_by: 'Post#user_id', foreign_key: :user_id # TODO: posts.exists?
+  cache_at :has_post2?, ->(id){ PostWithoutCache.where(user_id: id).exists? }, expire_by: 'PostWithoutCache#user_id', foreign_key: :user_id
 end

--- a/test/lib/seeds.rb
+++ b/test/lib/seeds.rb
@@ -16,6 +16,11 @@ ActiveRecord::Schema.define do
     t.string :title
   end
 
+  create_table :post_without_caches, :force => true do |t|
+    t.integer :user_id
+    t.string :title
+  end
+
   create_table :profiles, :force => true do |t|
     t.integer :user_id
     t.integer :point


### PR DESCRIPTION
if foreign_key is not id, it have to select foreign_key from database since `delete` only provides `id` information. 

It will trying to use the information in cache before hit database. If the model has `cache_self` and has been cached, it will not hit database.