### PR TITLE
use loaded model if possible to prevent extra queries

### DIFF
--- a/lib/active_model_cachers/active_record/attr_model.rb
+++ b/lib/active_model_cachers/active_record/attr_model.rb
@@ -63,12 +63,17 @@ module ActiveModelCachers
       end
 
       def query_model(binding, id)
-        return @klass.find_by(id: id) if @column == nil # Cache self
+        return query_self(binding, id) if @column == nil
         return query_association(binding, id) if association?
         return query_attribute(binding, id)
       end
 
       private
+
+      def query_self(binding, id)
+        return binding if binding.is_a?(::ActiveRecord::Base)
+        return @klass.find_by(id: id)
+      end
 
       def query_attribute(binding, id)
         return binding.send(@column) if binding.is_a?(::ActiveRecord::Base) and binding.has_attribute?(@column)

--- a/lib/active_model_cachers/active_record/attr_model.rb
+++ b/lib/active_model_cachers/active_record/attr_model.rb
@@ -62,7 +62,8 @@ module ActiveModelCachers
         return @reflect.collection?
       end
 
-      def query_model(id)
+      def query_model(binding, id)
+        return binding.send(@column) if association? and binding.is_a?(::ActiveRecord::Base)
         return @klass.find_by(id: id) if @column == nil # Cache self
         return @klass.where(id: id).limit(1).pluck(@column).first if not association? # Cache attributes
         id = @reflect.active_record.where(id: id).limit(1).pluck(foreign_key).first if foreign_key != 'id'

--- a/lib/active_model_cachers/active_record/cacher.rb
+++ b/lib/active_model_cachers/active_record/cacher.rb
@@ -41,8 +41,6 @@ module ActiveModelCachers
           if attr.has_one?
             data = @model.send(attr.column).try(primary_key)
           else
-            data = @model.send(attr.foreign_key)
-            service_klasses = [service_klasses.last]
           end
         end
         data ||= (@model ? @model.send(primary_key) : nil) || @id

--- a/lib/active_model_cachers/active_record/extension.rb
+++ b/lib/active_model_cachers/active_record/extension.rb
@@ -16,7 +16,7 @@ module ActiveModelCachers
         attr = AttrModel.new(self, column)
         return cache_belongs_to(attr) if attr.belongs_to?
 
-        query ||= ->(id){ attr.query_model(id) }
+        query ||= ->(id){ attr.query_model(self, id) }
         service_klass = CacheServiceFactory.create_for_active_model(attr, query)
         Cacher.define_cacher_method(attr, primary_key, [service_klass])
 

--- a/test/cache_at_attribute_test.rb
+++ b/test/cache_at_attribute_test.rb
@@ -18,7 +18,7 @@ class CacheAtAttributeTest < BaseTest
     assert_cache('active_model_cachers_Profile_at_point_1' => 10)
   end
 
-  def test_instance_cacher_to_use_association_cache
+  def test_instance_cacher_to_use_loaded_associations
     profile = Profile.first
 
     assert_queries(0){ assert_equal 10, profile.cacher.point }

--- a/test/cache_at_attribute_test.rb
+++ b/test/cache_at_attribute_test.rb
@@ -18,6 +18,13 @@ class CacheAtAttributeTest < BaseTest
     assert_cache('active_model_cachers_Profile_at_point_1' => 10)
   end
 
+  def test_instance_cacher_to_use_association_cache
+    profile = Profile.first
+
+    assert_queries(0){ assert_equal 10, profile.cacher.point }
+    assert_cache('active_model_cachers_Profile_at_point_1' => 10)
+  end
+
   # ----------------------------------------------------------------
   # ● Create
   # ----------------------------------------------------------------

--- a/test/cache_at_belongs_to_test.rb
+++ b/test/cache_at_belongs_to_test.rb
@@ -24,7 +24,7 @@ class CacheAtBelongsToTest < BaseTest
     language = user.language
 
     assert_queries(0){ assert_equal 'zh-tw', user.cacher.language.name }
-    assert_cache('active_model_cachers_Language_2' => language)
+    assert_cache('active_model_cachers_User_at_language_id_1' => 2, 'active_model_cachers_Language_2' => language)
   end
 
   # ----------------------------------------------------------------

--- a/test/cache_at_belongs_to_test.rb
+++ b/test/cache_at_belongs_to_test.rb
@@ -13,9 +13,16 @@ class CacheAtBelongsToTest < BaseTest
 
   def test_basic_usage_of_instance_cacher
     user = User.find_by(name: 'John1')
-    language = user.language
 
     assert_queries(1){ assert_equal 'zh-tw', user.cacher.language.name }
+    assert_queries(0){ assert_equal 'zh-tw', user.cacher.language.name }
+    assert_cache('active_model_cachers_Language_2' => user.language)
+  end
+
+  def test_instance_cacher_to_use_association_cache
+    user = User.find_by(name: 'John1')
+    language = user.language
+
     assert_queries(0){ assert_equal 'zh-tw', user.cacher.language.name }
     assert_cache('active_model_cachers_Language_2' => language)
   end

--- a/test/cache_at_belongs_to_test.rb
+++ b/test/cache_at_belongs_to_test.rb
@@ -19,7 +19,7 @@ class CacheAtBelongsToTest < BaseTest
     assert_cache('active_model_cachers_User_at_language_id_1' => 2, 'active_model_cachers_Language_2' => user.language)
   end
 
-  def test_instance_cacher_to_use_association_cache
+  def test_instance_cacher_to_use_loaded_associations
     user = User.find_by(name: 'John1')
     language = user.language
 
@@ -27,6 +27,12 @@ class CacheAtBelongsToTest < BaseTest
     assert_cache('active_model_cachers_User_at_language_id_1' => 2, 'active_model_cachers_Language_2' => language)
   end
 
+  def test_instance_cacher_to_use_preloaded_associations
+    user = User.includes(:language).find_by(name: 'John1')
+
+    assert_queries(0){ assert_equal 'zh-tw', user.cacher.language.name }
+    assert_cache('active_model_cachers_User_at_language_id_1' => 2, 'active_model_cachers_Language_2' => user.language)
+  end
   # ----------------------------------------------------------------
   # ● Create
   # ----------------------------------------------------------------

--- a/test/cache_at_belongs_to_test.rb
+++ b/test/cache_at_belongs_to_test.rb
@@ -16,7 +16,7 @@ class CacheAtBelongsToTest < BaseTest
 
     assert_queries(1){ assert_equal 'zh-tw', user.cacher.language.name }
     assert_queries(0){ assert_equal 'zh-tw', user.cacher.language.name }
-    assert_cache('active_model_cachers_Language_2' => user.language)
+    assert_cache('active_model_cachers_User_at_language_id_1' => 2, 'active_model_cachers_Language_2' => user.language)
   end
 
   def test_instance_cacher_to_use_association_cache

--- a/test/cache_at_has_many_test.rb
+++ b/test/cache_at_has_many_test.rb
@@ -22,7 +22,7 @@ class CacheAtHasManyTest < BaseTest
 
   def test_instance_cacher_to_use_association_cache
     user = User.find_by(name: 'John1')
-    posts = user.posts
+    posts = user.posts.to_a # to_a to make sure posts is loaded
 
     assert_queries(0){ assert_equal 3, user.cacher.posts.size }
     assert_cache('active_model_cachers_User_at_posts_1' => posts)

--- a/test/cache_at_has_many_test.rb
+++ b/test/cache_at_has_many_test.rb
@@ -17,6 +17,14 @@ class CacheAtHasManyTest < BaseTest
 
     assert_queries(1){ assert_equal 3, user.cacher.posts.size }
     assert_queries(0){ assert_equal 3, user.cacher.posts.size }
+    assert_cache('active_model_cachers_User_at_posts_1' => user.posts)
+  end
+
+  def test_instance_cacher_to_use_association_cache
+    user = User.find_by(name: 'John1')
+    posts = user.posts
+
+    assert_queries(0){ assert_equal 3, user.cacher.posts.size }
     assert_cache('active_model_cachers_User_at_posts_1' => posts)
   end
 

--- a/test/cache_at_has_many_test.rb
+++ b/test/cache_at_has_many_test.rb
@@ -20,12 +20,19 @@ class CacheAtHasManyTest < BaseTest
     assert_cache('active_model_cachers_User_at_posts_1' => user.posts)
   end
 
-  def test_instance_cacher_to_use_association_cache
+  def test_instance_cacher_to_use_loaded_associations
     user = User.find_by(name: 'John1')
     posts = user.posts.to_a # to_a to make sure posts is loaded
 
     assert_queries(0){ assert_equal 3, user.cacher.posts.size }
     assert_cache('active_model_cachers_User_at_posts_1' => posts)
+  end
+
+  def test_instance_cacher_to_use_preloaded_associations
+    user = User.includes(:posts).find_by(name: 'John1')
+
+    assert_queries(0){ assert_equal 3, user.cacher.posts.size }
+    assert_cache('active_model_cachers_User_at_posts_1' => user.posts)
   end
 
   # ----------------------------------------------------------------

--- a/test/cache_at_has_one_test.rb
+++ b/test/cache_at_has_one_test.rb
@@ -12,9 +12,16 @@ class CacheAtHasOneTest < BaseTest
 
   def test_basic_usage_of_instance_cacher
     user = User.find_by(name: 'John2')
-    profile = user.profile
 
     assert_queries(1){ assert_equal 10, user.cacher.profile.point }
+    assert_queries(0){ assert_equal 10, user.cacher.profile.point }
+    assert_cache('active_model_cachers_Profile_1' => user.profile)
+  end
+
+  def test_instance_cacher_to_use_association_cache
+    user = User.find_by(name: 'John2')
+    profile = user.profile
+
     assert_queries(0){ assert_equal 10, user.cacher.profile.point }
     assert_cache('active_model_cachers_Profile_1' => profile)
   end

--- a/test/cache_at_has_one_test.rb
+++ b/test/cache_at_has_one_test.rb
@@ -18,12 +18,19 @@ class CacheAtHasOneTest < BaseTest
     assert_cache('active_model_cachers_Profile_1' => user.profile)
   end
 
-  def test_instance_cacher_to_use_association_cache
+  def test_instance_cacher_to_use_loaded_associations
     user = User.find_by(name: 'John2')
     profile = user.profile
 
     assert_queries(0){ assert_equal 10, user.cacher.profile.point }
     assert_cache('active_model_cachers_Profile_1' => profile)
+  end
+
+  def test_instance_cacher_to_use_preloaded_associations
+    user = User.includes(:profile).find_by(name: 'John2')
+
+    assert_queries(0){ assert_equal 10, user.cacher.profile.point }
+    assert_cache('active_model_cachers_Profile_1' => user.profile)
   end
 
   # ----------------------------------------------------------------


### PR DESCRIPTION
For example, if posts are preloaded by `includes`, no extra query will be made to get posts on cache miss. 
```rb
user = User.includes(:posts).first
user.cacher.posts # no query made
```

It also works with manually load.
```rb
user = User.first
user.posts.to_a
user.cacher.posts # no query made
```