### PR TITLE
Prevent infinite loop if someone override default associations' method

### DIFF
--- a/lib/active_model_cachers/active_record/attr_model.rb
+++ b/lib/active_model_cachers/active_record/attr_model.rb
@@ -83,7 +83,7 @@ module ActiveModelCachers
       end
 
       def query_association(binding, id)
-        return binding.send(@column) if binding.is_a?(::ActiveRecord::Base)
+        return binding.association(@column).load_target if binding.is_a?(::ActiveRecord::Base)
         id = @reflect.active_record.where(id: id).limit(1).pluck(foreign_key).first if foreign_key != 'id'
         if @reflect.collection?
           return id ? @reflect.klass.where(@reflect.foreign_key => id).to_a : []

--- a/lib/active_model_cachers/active_record/cacher.rb
+++ b/lib/active_model_cachers/active_record/cacher.rb
@@ -43,10 +43,11 @@ module ActiveModelCachers
       def exec_by(attr, primary_key, service_klasses, method)
         bindings = [@model]
         if @model and attr.association?
+          target = @model.association(attr.column).load_target
           if attr.has_one?
-            data = @model.send(attr.column).try(primary_key)
+            data = target.try(primary_key)
           else
-            bindings << @model.send(attr.column) if @model.is_a?(::ActiveRecord::Base)
+            bindings << target
           end
         end
         data ||= (@model ? @model.send(primary_key) : nil) || @id

--- a/lib/active_model_cachers/active_record/cacher.rb
+++ b/lib/active_model_cachers/active_record/cacher.rb
@@ -43,11 +43,11 @@ module ActiveModelCachers
       def exec_by(attr, primary_key, service_klasses, method)
         bindings = [@model]
         if @model and attr.association?
-          target = @model.association(attr.column).load_target
+          get_target = ->{ @model.association(attr.column).load_target }
           if attr.has_one?
-            data = target.try(primary_key)
+            data = get_target.call.try(primary_key)
           else
-            bindings << target
+            bindings << get_target.call if method != :clean_cache # no need to load binding when just cleaning cache
           end
         end
         data ||= (@model ? @model.send(primary_key) : nil) || @id

--- a/test/override_association_method_test.rb
+++ b/test/override_association_method_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'base_test'
+
+class OverrideAssociationMethodTest < BaseTest
+  def test_override_belongs_to_association_method
+    user = User.find_by(name: 'John2')
+    language = user.language
+
+    counter = 1
+    user.define_singleton_method(:language) do
+      counter += 1
+      raise SystemStackError.new('stack level too deep') if counter > 3
+      next cacher.language
+    end
+
+    assert_queries(0){ assert_equal 'zh-tw', user.cacher.language.name }
+    assert_cache('active_model_cachers_User_at_language_id_2' => 2, 'active_model_cachers_Language_2' => language)
+  end
+end


### PR DESCRIPTION
For example, this will cause infinite loop because `cacher.profile` will call `user.profile` to get profile object, and `user.profile` will call `cacher.profile` to get profile from cache.
```rb
class User < ActiveRecord::Base
  has_one :profile
  cache_at :profile

  def profile
    cacher.profile
  end
end
```