### PR TITLE
[Fix] will send query even if has one association is cached

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ end
 @profile = current_user.cacher.profile
 
 # directly get profile without loading user.
-@profile = User.cacher_at(profile_id).profile
+@profile = User.cacher_at(user_id).profile
 ```
 
 ### Caching Polymorphic Associations

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ current_user.cacher.clean(:profile)
 
 # Or calling the clean_* method
 current_user.cacher.clean_profile
+
+# clean the cache without loading model
+User.cacher_at(user_id).clean_profile
 ```
 
 ## Smart Caching

--- a/lib/active_model_cachers/active_record/attr_model.rb
+++ b/lib/active_model_cachers/active_record/attr_model.rb
@@ -88,9 +88,9 @@ module ActiveModelCachers
         return binding.association(@column).load_target if binding.is_a?(::ActiveRecord::Base)
         id = @reflect.active_record.where(id: id).limit(1).pluck(foreign_key).first if foreign_key != 'id'
         case
-        when @reflect.collection? ; return id ? @reflect.klass.where(@reflect.foreign_key => id).to_a : []
-        when @reflect.has_one?    ; return id ? @reflect.klass.find_by(foreign_key(reverse: true) => id) : nil
-        else                      ; return id ? @reflect.klass.find_by(primary_key => id) : nil
+        when collection? ; return id ? @reflect.klass.where(@reflect.foreign_key => id).to_a : []
+        when has_one?    ; return id ? @reflect.klass.find_by(foreign_key(reverse: true) => id) : nil
+        else             ; return id ? @reflect.klass.find_by(primary_key => id) : nil
         end
       end
     end

--- a/lib/active_model_cachers/active_record/attr_model.rb
+++ b/lib/active_model_cachers/active_record/attr_model.rb
@@ -4,10 +4,11 @@ module ActiveModelCachers
     class AttrModel
       attr_reader :klass, :column, :reflect
 
-      def initialize(klass, column, primary_key: nil)
+      def initialize(klass, column, primary_key: nil, foreign_key: nil)
         @klass = klass
         @column = column
         @primary_key = primary_key
+        @foreign_key = foreign_key
         @reflect = klass.reflect_on_association(column)
       end
 
@@ -48,6 +49,7 @@ module ActiveModelCachers
       end
 
       def foreign_key(reverse: false)
+        return @foreign_key if @foreign_key
         return if not association?
         # key may be symbol if specify foreign_key in association options
         return @reflect.chain.last.foreign_key.to_s if reverse and join_table
@@ -85,10 +87,10 @@ module ActiveModelCachers
       def query_association(binding, id)
         return binding.association(@column).load_target if binding.is_a?(::ActiveRecord::Base)
         id = @reflect.active_record.where(id: id).limit(1).pluck(foreign_key).first if foreign_key != 'id'
-        if @reflect.collection?
-          return id ? @reflect.klass.where(@reflect.foreign_key => id).to_a : []
-        else
-          return id ? @reflect.klass.find_by(primary_key => id) : nil
+        case
+        when @reflect.collection? ; return id ? @reflect.klass.where(@reflect.foreign_key => id).to_a : []
+        when @reflect.has_one?    ; return id ? @reflect.klass.find_by(foreign_key(reverse: true) => id) : nil
+        else                      ; return id ? @reflect.klass.find_by(primary_key => id) : nil
         end
       end
     end

--- a/lib/active_model_cachers/active_record/cacher.rb
+++ b/lib/active_model_cachers/active_record/cacher.rb
@@ -43,12 +43,12 @@ module ActiveModelCachers
       def exec_by(attr, primary_key, service_klasses, method)
         bindings = [@model]
         if @model and attr.association?
-          get_target = ->{ @model.association(attr.column).load_target }
+          association = @model.association(attr.column)
           case
           when attr.has_one?
-            data = get_target.call.try(primary_key)
+            data = association.load_target.try(primary_key)
           when attr.belongs_to?
-            bindings << get_target.call if method != :clean_cache # no need to load binding when just cleaning cache
+            bindings << association.load_target if association.loaded? and method != :clean_cache # no need to load binding when just cleaning cache
           end
         end
         data ||= (@model ? @model.send(primary_key) : nil) || @id

--- a/lib/active_model_cachers/active_record/cacher.rb
+++ b/lib/active_model_cachers/active_record/cacher.rb
@@ -44,9 +44,10 @@ module ActiveModelCachers
         bindings = [@model]
         if @model and attr.association?
           get_target = ->{ @model.association(attr.column).load_target }
-          if attr.has_one?
+          case
+          when attr.has_one?
             data = get_target.call.try(primary_key)
-          else
+          when attr.belongs_to?
             bindings << get_target.call if method != :clean_cache # no need to load binding when just cleaning cache
           end
         end

--- a/lib/active_model_cachers/active_record/cacher.rb
+++ b/lib/active_model_cachers/active_record/cacher.rb
@@ -46,7 +46,7 @@ module ActiveModelCachers
           association = @model.association(attr.column)
           case
           when attr.has_one?
-            data = association.load_target.try(primary_key)
+            # data = association.load_target.try(primary_key)
           when attr.belongs_to?
             bindings << association.load_target if association.loaded? and method != :clean_cache # no need to load binding when just cleaning cache
           end

--- a/lib/active_model_cachers/active_record/cacher.rb
+++ b/lib/active_model_cachers/active_record/cacher.rb
@@ -43,12 +43,9 @@ module ActiveModelCachers
       def exec_by(attr, primary_key, service_klasses, method)
         bindings = [@model]
         if @model and attr.association?
-          association = @model.association(attr.column)
-          case
-          when attr.has_one?
-            # data = association.load_target.try(primary_key)
-          when attr.belongs_to?
-            bindings << association.load_target if association.loaded? and method != :clean_cache # no need to load binding when just cleaning cache
+          if attr.belongs_to? and method != :clean_cache # no need to load binding when just cleaning cache
+            association = @model.association(attr.column)
+            bindings << association.load_target if association.loaded?
           end
         end
         data ||= (@model ? @model.send(primary_key) : nil) || @id

--- a/lib/active_model_cachers/active_record/extension.rb
+++ b/lib/active_model_cachers/active_record/extension.rb
@@ -14,7 +14,7 @@ module ActiveModelCachers
       end
 
       def cache_at(column, query = nil, expire_by: nil, on: nil, foreign_key: nil, primary_key: nil)
-        attr = AttrModel.new(self, column, primary_key: primary_key)
+        attr = AttrModel.new(self, column, foreign_key: foreign_key, primary_key: primary_key)
         return cache_belongs_to(attr) if attr.belongs_to?
 
         query ||= ->(id){ attr.query_model(self, id) }

--- a/lib/active_model_cachers/cache_service_factory.rb
+++ b/lib/active_model_cachers/cache_service_factory.rb
@@ -31,7 +31,8 @@ module ActiveModelCachers
       def get_cache_key(attr)
         class_name, column = (attr.single_association? ? [attr.class_name, nil] : [attr.klass, attr.column])
         return "active_model_cachers_#{class_name}_at_#{column}" if column
-        return "active_model_cachers_#{class_name}_by_#{attr.primary_key}" if attr.primary_key and attr.primary_key.to_s != 'id'
+        foreign_key = attr.foreign_key(reverse: true)
+        return "active_model_cachers_#{class_name}_by_#{foreign_key}" if foreign_key and foreign_key.to_s != 'id'
         return "active_model_cachers_#{class_name}"
       end
     end

--- a/test/cache_at_attribute_test.rb
+++ b/test/cache_at_attribute_test.rb
@@ -18,6 +18,15 @@ class CacheAtAttributeTest < BaseTest
     assert_cache('active_model_cachers_Profile_at_point_1' => 10)
   end
 
+  def test_instance_cacher_without_association_cache
+    profile1 = Profile.select(:id).first # The only use case of this may be that profile doesn't select the attribute.
+    profile2 = Profile.select(:id).first # The only use case of this may be that profile doesn't select the attribute.
+
+    assert_queries(1){ assert_equal 10, profile1.cacher.point }
+    assert_queries(0){ assert_equal 10, profile2.cacher.point }
+    assert_cache('active_model_cachers_Profile_at_point_1' => 10)
+  end
+
   def test_instance_cacher_to_use_loaded_associations
     profile = Profile.first
 

--- a/test/cache_at_belongs_to_test.rb
+++ b/test/cache_at_belongs_to_test.rb
@@ -19,6 +19,15 @@ class CacheAtBelongsToTest < BaseTest
     assert_cache('active_model_cachers_User_at_language_id_1' => 2, 'active_model_cachers_Language_2' => user.language)
   end
 
+  def test_instance_cacher_without_association_cache
+    user1 = User.find_by(name: 'John1')
+    user2 = User.find_by(name: 'John1')
+
+    assert_queries(1){ assert_equal 'zh-tw', user1.cacher.language.name }
+    assert_queries(0){ assert_equal 'zh-tw', user2.cacher.language.name }
+    assert_cache('active_model_cachers_User_at_language_id_1' => 2, 'active_model_cachers_Language_2' => user.language)
+  end
+
   def test_instance_cacher_to_use_loaded_associations
     user = User.find_by(name: 'John1')
     language = user.language

--- a/test/cache_at_belongs_to_test.rb
+++ b/test/cache_at_belongs_to_test.rb
@@ -25,7 +25,7 @@ class CacheAtBelongsToTest < BaseTest
 
     assert_queries(1){ assert_equal 'zh-tw', user1.cacher.language.name }
     assert_queries(0){ assert_equal 'zh-tw', user2.cacher.language.name }
-    assert_cache('active_model_cachers_User_at_language_id_1' => 2, 'active_model_cachers_Language_2' => user.language)
+    assert_cache('active_model_cachers_User_at_language_id_1' => 2, 'active_model_cachers_Language_2' => user1.language)
   end
 
   def test_instance_cacher_to_use_loaded_associations

--- a/test/cache_at_has_many_test.rb
+++ b/test/cache_at_has_many_test.rb
@@ -13,11 +13,19 @@ class CacheAtHasManyTest < BaseTest
 
   def test_basic_usage_of_instance_cacher
     user = User.find_by(name: 'John1')
-    posts = user.posts
 
     assert_queries(1){ assert_equal 3, user.cacher.posts.size }
     assert_queries(0){ assert_equal 3, user.cacher.posts.size }
     assert_cache('active_model_cachers_User_at_posts_1' => user.posts)
+  end
+
+  def test_instance_cacher_without_association_cache
+    user1 = User.find_by(name: 'John1')
+    user2 = User.find_by(name: 'John1')
+
+    assert_queries(1){ assert_equal 3, user1.cacher.posts.size }
+    assert_queries(0){ assert_equal 3, user2.cacher.posts.size }
+    assert_cache('active_model_cachers_User_at_posts_1' => user1.posts)
   end
 
   def test_instance_cacher_to_use_loaded_associations

--- a/test/cache_at_has_one_test.rb
+++ b/test/cache_at_has_one_test.rb
@@ -18,6 +18,15 @@ class CacheAtHasOneTest < BaseTest
     assert_cache('active_model_cachers_Profile_1' => user.profile)
   end
 
+  def test_instance_cacher_without_association_cache
+    user1 = User.find_by(name: 'John2')
+    user2 = User.find_by(name: 'John2')
+
+    assert_queries(1){ assert_equal 10, user1.cacher.profile.point }
+    assert_queries(0){ assert_equal 10, user2.cacher.profile.point }
+    assert_cache('active_model_cachers_Profile_1' => user1.profile)
+  end
+
   def test_instance_cacher_to_use_loaded_associations
     user = User.find_by(name: 'John2')
     profile = user.profile

--- a/test/cache_at_has_one_test.rb
+++ b/test/cache_at_has_one_test.rb
@@ -191,7 +191,7 @@ class CacheAtHasOneTest < BaseTest
   end
 
   def test_destroyed_by_dependent_delete
-    profile = Profile.create(id: -3, point: 17)
+    profile = Profile.create(id: -3, user_id: -2, point: 17)
     user = User.create(id: -2, profile: profile)
 
     assert_queries(1){ assert_equal 17, User.cacher_at(-2).profile.point }

--- a/test/cache_at_has_one_test.rb
+++ b/test/cache_at_has_one_test.rb
@@ -71,7 +71,7 @@ class CacheAtHasOneTest < BaseTest
     Rails.cache.write('active_model_cachers_Profile_by_user_id_2', profile)
     assert_cache('active_model_cachers_Profile_by_user_id_2' => profile)
 
-    assert_queries(0){ User.cacher_at(profile.id).clean_profile }
+    assert_queries(0){ User.cacher_at(2).clean_profile }
     assert_cache({})
   end
 
@@ -81,7 +81,7 @@ class CacheAtHasOneTest < BaseTest
     Rails.cache.write('active_model_cachers_Profile_by_user_id_2', profile)
     assert_cache('active_model_cachers_Profile_by_user_id_2' => profile)
 
-    assert_queries(0){ User.cacher_at(profile.id).clean(:profile) }
+    assert_queries(0){ User.cacher_at(2).clean(:profile) }
     assert_cache({})
   end
 
@@ -191,8 +191,8 @@ class CacheAtHasOneTest < BaseTest
   end
 
   def test_destroyed_by_dependent_delete
-    profile = Profile.create(id: -3, user_id: -2, point: 17)
-    user = User.create(profile: profile)
+    profile = Profile.create(id: -3, point: 17)
+    user = User.create(id: -2, profile: profile)
 
     assert_queries(1){ assert_equal 17, User.cacher_at(-2).profile.point }
     assert_queries(0){ assert_equal 17, User.cacher_at(-2).profile.point }

--- a/test/cache_at_has_one_test.rb
+++ b/test/cache_at_has_one_test.rb
@@ -3,11 +3,11 @@ require 'base_test'
 
 class CacheAtHasOneTest < BaseTest
   def test_basic_usage
-    profile = User.find_by(name: 'John2').profile
+    user = User.find_by(name: 'John2')
 
-    assert_queries(1){ assert_equal 10, User.cacher_at(profile.id).profile.point }
-    assert_queries(0){ assert_equal 10, User.cacher_at(profile.id).profile.point }
-    assert_cache('active_model_cachers_Profile_1' => profile)
+    assert_queries(1){ assert_equal 10, User.cacher_at(2).profile.point }
+    assert_queries(0){ assert_equal 10, User.cacher_at(2).profile.point }
+    assert_cache('active_model_cachers_Profile_by_user_id_2' => user.profile)
   end
 
   def test_basic_usage_of_instance_cacher
@@ -15,7 +15,7 @@ class CacheAtHasOneTest < BaseTest
 
     assert_queries(1){ assert_equal 10, user.cacher.profile.point }
     assert_queries(0){ assert_equal 10, user.cacher.profile.point }
-    assert_cache('active_model_cachers_Profile_1' => user.profile)
+    assert_cache('active_model_cachers_Profile_by_user_id_2' => user.profile)
   end
 
   def test_instance_cacher_without_association_cache
@@ -24,7 +24,7 @@ class CacheAtHasOneTest < BaseTest
 
     assert_queries(1){ assert_equal 10, user1.cacher.profile.point }
     assert_queries(0){ assert_equal 10, user2.cacher.profile.point }
-    assert_cache('active_model_cachers_Profile_1' => user1.profile)
+    assert_cache('active_model_cachers_Profile_by_user_id_2' => user1.profile)
   end
 
   def test_instance_cacher_to_use_loaded_associations
@@ -32,14 +32,14 @@ class CacheAtHasOneTest < BaseTest
     profile = user.profile
 
     assert_queries(0){ assert_equal 10, user.cacher.profile.point }
-    assert_cache('active_model_cachers_Profile_1' => profile)
+    assert_cache('active_model_cachers_Profile_by_user_id_2' => profile)
   end
 
   def test_instance_cacher_to_use_preloaded_associations
     user = User.includes(:profile).find_by(name: 'John2')
 
     assert_queries(0){ assert_equal 10, user.cacher.profile.point }
-    assert_cache('active_model_cachers_Profile_1' => user.profile)
+    assert_cache('active_model_cachers_Profile_by_user_id_2' => user.profile)
   end
 
   # ----------------------------------------------------------------
@@ -50,14 +50,14 @@ class CacheAtHasOneTest < BaseTest
 
     assert_queries(1){ assert_nil User.cacher_at(-1).profile }
     assert_queries(0){ assert_nil User.cacher_at(-1).profile }
-    assert_cache('active_model_cachers_Profile_-1' => ActiveModelCachers::NilObject)
+    assert_cache('active_model_cachers_Profile_by_user_id_-1' => ActiveModelCachers::NilObject)
 
-    assert_queries(1){ profile = Profile.create(id: -1, point: 3) }
+    assert_queries(1){ profile = Profile.create(id: -2, user_id: -1, point: 3) }
     assert_cache({})
 
     assert_queries(1){ assert_equal 3, User.cacher_at(-1).profile.point }
     assert_queries(0){ assert_equal 3, User.cacher_at(-1).profile.point }
-    assert_cache('active_model_cachers_Profile_-1' => profile)
+    assert_cache('active_model_cachers_Profile_by_user_id_-1' => profile)
   ensure
     profile.destroy if profile
   end
@@ -68,8 +68,8 @@ class CacheAtHasOneTest < BaseTest
   def test_clean
     profile = User.find_by(name: 'John2').profile
 
-    Rails.cache.write('active_model_cachers_Profile_1', profile)
-    assert_cache('active_model_cachers_Profile_1' => profile)
+    Rails.cache.write('active_model_cachers_Profile_by_user_id_2', profile)
+    assert_cache('active_model_cachers_Profile_by_user_id_2' => profile)
 
     assert_queries(0){ User.cacher_at(profile.id).clean_profile }
     assert_cache({})
@@ -78,8 +78,8 @@ class CacheAtHasOneTest < BaseTest
   def test_clean2
     profile = User.find_by(name: 'John2').profile
 
-    Rails.cache.write('active_model_cachers_Profile_1', profile)
-    assert_cache('active_model_cachers_Profile_1' => profile)
+    Rails.cache.write('active_model_cachers_Profile_by_user_id_2', profile)
+    assert_cache('active_model_cachers_Profile_by_user_id_2' => profile)
 
     assert_queries(0){ User.cacher_at(profile.id).clean(:profile) }
     assert_cache({})
@@ -88,8 +88,8 @@ class CacheAtHasOneTest < BaseTest
   def test_clean_in_instance_cacher
     user = User.find_by(name: 'John2')
 
-    Rails.cache.write('active_model_cachers_Profile_1', user.profile)
-    assert_cache('active_model_cachers_Profile_1' => user.profile)
+    Rails.cache.write('active_model_cachers_Profile_by_user_id_2', user.profile)
+    assert_cache('active_model_cachers_Profile_by_user_id_2' => user.profile)
 
     assert_queries(0){ user.cacher.clean_profile }
     assert_cache({})
@@ -100,30 +100,30 @@ class CacheAtHasOneTest < BaseTest
   def test_update_nothing
     profile = User.find_by(name: 'John2').profile
 
-    assert_queries(1){ assert_equal 10, User.cacher_at(profile.id).profile.point }
-    assert_queries(0){ assert_equal 10, User.cacher_at(profile.id).profile.point }
-    assert_cache('active_model_cachers_Profile_1' => profile)
+    assert_queries(1){ assert_equal 10, User.cacher_at(2).profile.point }
+    assert_queries(0){ assert_equal 10, User.cacher_at(2).profile.point }
+    assert_cache('active_model_cachers_Profile_by_user_id_2' => profile)
 
     assert_queries(0){ profile.save }
-    assert_cache('active_model_cachers_Profile_1' => profile)
+    assert_cache('active_model_cachers_Profile_by_user_id_2' => profile)
 
-    assert_queries(0){ assert_equal 10, User.cacher_at(profile.id).profile.point }
-    assert_cache('active_model_cachers_Profile_1' => profile)
+    assert_queries(0){ assert_equal 10, User.cacher_at(2).profile.point }
+    assert_cache('active_model_cachers_Profile_by_user_id_2' => profile)
   end
 
   def test_update
     profile = User.find_by(name: 'John2').profile
 
-    assert_queries(1){ assert_equal 10, User.cacher_at(profile.id).profile.point }
-    assert_queries(0){ assert_equal 10, User.cacher_at(profile.id).profile.point }
-    assert_cache('active_model_cachers_Profile_1' => profile)
+    assert_queries(1){ assert_equal 10, User.cacher_at(2).profile.point }
+    assert_queries(0){ assert_equal 10, User.cacher_at(2).profile.point }
+    assert_cache('active_model_cachers_Profile_by_user_id_2' => profile)
 
     assert_queries(1){ profile.update_attributes(point: 12) }
     assert_cache({})
 
-    assert_queries(1){ assert_equal 12, User.cacher_at(profile.id).profile.point }
-    assert_queries(0){ assert_equal 12, User.cacher_at(profile.id).profile.point }
-    assert_cache('active_model_cachers_Profile_1' => profile)
+    assert_queries(1){ assert_equal 12, User.cacher_at(2).profile.point }
+    assert_queries(0){ assert_equal 12, User.cacher_at(2).profile.point }
+    assert_cache('active_model_cachers_Profile_by_user_id_2' => profile)
   ensure
     profile.update_attributes(point: 10)
   end
@@ -136,16 +136,16 @@ class CacheAtHasOneTest < BaseTest
       contact.class.cacher
     end
 
-    assert_queries(1){ assert_equal '12345', User.cacher_at(contact.id).contact.phone }
-    assert_queries(0){ assert_equal '12345', User.cacher_at(contact.id).contact.phone }
-    assert_cache('active_model_cachers_Contact_1' => contact)
+    assert_queries(1){ assert_equal '12345', User.cacher_at(1).contact.phone }
+    assert_queries(0){ assert_equal '12345', User.cacher_at(1).contact.phone }
+    assert_cache('active_model_cachers_Contact_by_user_id_1' => contact)
 
     assert_queries(1){ contact.update_attributes(phone: '12346') }
     assert_cache({})
 
-    assert_queries(1){ assert_equal '12346', User.cacher_at(contact.id).contact.phone }
-    assert_queries(0){ assert_equal '12346', User.cacher_at(contact.id).contact.phone }
-    assert_cache('active_model_cachers_Contact_1' => contact)
+    assert_queries(1){ assert_equal '12346', User.cacher_at(1).contact.phone }
+    assert_queries(0){ assert_equal '12346', User.cacher_at(1).contact.phone }
+    assert_cache('active_model_cachers_Contact_by_user_id_1' => contact)
   ensure
     contact.update_attributes(phone: '12345')
   end
@@ -154,18 +154,18 @@ class CacheAtHasOneTest < BaseTest
   # ● Destroy
   # ----------------------------------------------------------------
   def test_destroy
-    profile = Profile.create(point: 13)
+    profile = Profile.create(id: -3, user_id: -2, point: 13)
 
-    assert_queries(1){ assert_equal 13, User.cacher_at(profile.id).profile.point }
-    assert_queries(0){ assert_equal 13, User.cacher_at(profile.id).profile.point }
-    assert_cache("active_model_cachers_Profile_#{profile.id}" => profile)
+    assert_queries(1){ assert_equal 13, User.cacher_at(-2).profile.point }
+    assert_queries(0){ assert_equal 13, User.cacher_at(-2).profile.point }
+    assert_cache('active_model_cachers_Profile_by_user_id_-2' => profile)
 
     assert_queries(1){ profile.destroy }
     assert_cache({})
 
-    assert_queries(1){ assert_nil User.cacher_at(profile.id).profile }
-    assert_queries(0){ assert_nil User.cacher_at(profile.id).profile }
-    assert_cache("active_model_cachers_Profile_#{profile.id}" => ActiveModelCachers::NilObject)
+    assert_queries(1){ assert_nil User.cacher_at(-2).profile }
+    assert_queries(0){ assert_nil User.cacher_at(-2).profile }
+    assert_cache('active_model_cachers_Profile_by_user_id_-2' => ActiveModelCachers::NilObject)
   ensure
     profile.destroy
   end
@@ -174,36 +174,36 @@ class CacheAtHasOneTest < BaseTest
   # ● Delete
   # ----------------------------------------------------------------
   def test_delete
-    profile = Profile.create(point: 13)
+    profile = Profile.create(id: -3, user_id: -2, point: 13)
 
-    assert_queries(1){ assert_equal 13, User.cacher_at(profile.id).profile.point }
-    assert_queries(0){ assert_equal 13, User.cacher_at(profile.id).profile.point }
-    assert_cache("active_model_cachers_Profile_#{profile.id}" => profile)
+    assert_queries(1){ assert_equal 13, User.cacher_at(-2).profile.point }
+    assert_queries(0){ assert_equal 13, User.cacher_at(-2).profile.point }
+    assert_cache('active_model_cachers_Profile_by_user_id_-2' => profile)
 
     assert_queries(1){ profile.delete }
     assert_cache({})
 
-    assert_queries(1){ assert_nil User.cacher_at(profile.id).profile }
-    assert_queries(0){ assert_nil User.cacher_at(profile.id).profile }
-    assert_cache("active_model_cachers_Profile_#{profile.id}" => ActiveModelCachers::NilObject)
+    assert_queries(1){ assert_nil User.cacher_at(-2).profile }
+    assert_queries(0){ assert_nil User.cacher_at(-2).profile }
+    assert_cache('active_model_cachers_Profile_by_user_id_-2' => ActiveModelCachers::NilObject)
   ensure
-    profile.delete
+    profile.destroy
   end
 
   def test_destroyed_by_dependent_delete
-    profile = Profile.create(point: 17)
+    profile = Profile.create(id: -3, user_id: -2, point: 17)
     user = User.create(profile: profile)
 
-    assert_queries(1){ assert_equal 17, User.cacher_at(profile.id).profile.point }
-    assert_queries(0){ assert_equal 17, User.cacher_at(profile.id).profile.point }
-    assert_cache("active_model_cachers_Profile_#{profile.id}" => profile)
+    assert_queries(1){ assert_equal 17, User.cacher_at(-2).profile.point }
+    assert_queries(0){ assert_equal 17, User.cacher_at(-2).profile.point }
+    assert_cache('active_model_cachers_Profile_by_user_id_-2' => profile)
 
     assert_queries(3){ user.destroy } # 1. delete user. 2: delete profile by dependent. 3: delete contact by dependent.
     assert_cache({})
 
-    assert_queries(1){ assert_nil User.cacher_at(profile.id).profile }
-    assert_queries(0){ assert_nil User.cacher_at(profile.id).profile }
-    assert_cache("active_model_cachers_Profile_#{profile.id}" => ActiveModelCachers::NilObject)
+    assert_queries(1){ assert_nil User.cacher_at(-2).profile }
+    assert_queries(0){ assert_nil User.cacher_at(-2).profile }
+    assert_cache('active_model_cachers_Profile_by_user_id_-2' => ActiveModelCachers::NilObject)
   ensure
     user.destroy
   end

--- a/test/cache_bool_data_test.rb
+++ b/test/cache_bool_data_test.rb
@@ -27,6 +27,15 @@ class CacheBoolDataTest < BaseTest
     assert_cache('active_model_cachers_User_at_has_post?_1' => true)
   end
 
+  def test_instance_cacher_without_association_cache
+    user1 = User.find_by(name: 'John1')
+    user2 = User.find_by(name: 'John1')
+
+    assert_queries(1){ assert_equal true, user1.cacher.has_post? }
+    assert_queries(0){ assert_equal true, user2.cacher.has_post? }
+    assert_cache('active_model_cachers_User_at_has_post?_1' => true)
+  end
+
   # ----------------------------------------------------------------
   # ● Create
   # ----------------------------------------------------------------

--- a/test/cache_email_valid_test.rb
+++ b/test/cache_email_valid_test.rb
@@ -4,6 +4,7 @@ require 'base_test'
 class CacheEmailValidTest < BaseTest
   def test_basic_usage
     user = User.find_by(name: 'John2')
+
     assert_queries(1){ assert_equal true, User.cacher_at('john2@example.com').email_valid? }
     assert_queries(0){ assert_equal true, User.cacher_at('john2@example.com').email_valid? }
     assert_cache('active_model_cachers_User_at_email_valid?_john2@example.com' => true)
@@ -11,8 +12,18 @@ class CacheEmailValidTest < BaseTest
 
   def test_basic_usage_of_instance_cacher
     user = User.find_by(name: 'John2')
+
     assert_queries(1){ assert_equal true, user.cacher.email_valid? }
     assert_queries(0){ assert_equal true, user.cacher.email_valid? }
+    assert_cache('active_model_cachers_User_at_email_valid?_john2@example.com' => true)
+  end
+
+  def test_instance_cacher_without_association_cache
+    user1 = User.find_by(name: 'John2')
+    user2 = User.find_by(name: 'John2')
+
+    assert_queries(1){ assert_equal true, user1.cacher.email_valid? }
+    assert_queries(0){ assert_equal true, user2.cacher.email_valid? }
     assert_cache('active_model_cachers_User_at_email_valid?_john2@example.com' => true)
   end
 

--- a/test/cache_self_test.rb
+++ b/test/cache_self_test.rb
@@ -94,18 +94,18 @@ class CacheSelfTest < BaseTest
   # ● Destroy
   # ----------------------------------------------------------------
   def test_destroy
-    profile = Profile.create(point: 13)
+    profile = Profile.create(id: -3, user_id: -11, point: 13)
 
-    assert_queries(1){ assert_equal 13, Profile.cacher_at(profile.id).self.point }
-    assert_queries(0){ assert_equal 13, Profile.cacher_at(profile.id).self.point }
-    assert_cache("active_model_cachers_Profile_#{profile.id}" => profile)
+    assert_queries(1){ assert_equal 13, Profile.cacher_at(-3).self.point }
+    assert_queries(0){ assert_equal 13, Profile.cacher_at(-3).self.point }
+    assert_cache('active_model_cachers_Profile_-3' => profile)
 
     assert_queries(1){ profile.destroy }
     assert_cache({})
 
-    assert_queries(1){ assert_nil User.cacher_at(profile.id).profile }
-    assert_queries(0){ assert_nil User.cacher_at(profile.id).profile }
-    assert_cache("active_model_cachers_Profile_#{profile.id}" => ActiveModelCachers::NilObject)
+    assert_queries(1){ assert_nil User.cacher_at(-11).profile }
+    assert_queries(0){ assert_nil User.cacher_at(-11).profile }
+    assert_cache('active_model_cachers_Profile_by_user_id_-11' => ActiveModelCachers::NilObject)
   ensure
     profile.destroy
   end

--- a/test/instance_scope_test.rb
+++ b/test/instance_scope_test.rb
@@ -10,6 +10,15 @@ class InstanceScopeTest < BaseTest
     assert_cache('active_model_cachers_User_at_has_post2?_1' => true)
   end
 
+  def test_without_association_cache
+    user1 = User.find_by(name: 'John1')
+    user2 = User.find_by(name: 'John1')
+
+    assert_queries(1){ assert_equal true, user1.cacher.has_post2? }
+    assert_queries(0){ assert_equal true, user2.cacher.has_post2? }
+    assert_cache('active_model_cachers_User_at_has_post2?_1' => true)
+  end
+
   # ----------------------------------------------------------------
   # ● Create
   # ----------------------------------------------------------------

--- a/test/override_association_method_test.rb
+++ b/test/override_association_method_test.rb
@@ -29,7 +29,7 @@ class OverrideAssociationMethodTest < BaseTest
     end
 
     assert_queries(0){ assert_equal 10, user.cacher.profile.point }
-    assert_cache('active_model_cachers_Profile_1' => profile)
+    assert_cache('active_model_cachers_Profile_by_user_id_2' => profile)
   end
 
   def test_override_has_many_association_method


### PR DESCRIPTION
For example:
```rb
user1 = User.first
user2 = User.first

user1.cacher.profile
# => SELECT  `profiles`.* FROM `profiles` WHERE `profiles`.`user_id` = 1

user1.cacher.profile
# => SELECT  `profiles`.* FROM `profiles` WHERE `profiles`.`user_id` = 1
```