### PR TITLE
Change the syntax of getting self from cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ class User < ActiveRecord::Base
   cache_self
 end
 
-@user = User.cacher_at(user_id).self
+@user = User.cacher.find_by(id: user_id)
 ```
 
 Also support caching self by other columns.
@@ -210,7 +210,7 @@ class User < ActiveRecord::Base
   cache_self, by: :account
 end
 
-@user = User.cacher_at('khiav').self_by_account
+@user = User.cacher.find_by(account: 'khiav')
 ```
 
 ### Caching Attributes

--- a/README.md
+++ b/README.md
@@ -202,15 +202,27 @@ class User < ActiveRecord::Base
 end
 
 @user = User.cacher.find_by(id: user_id)
+
+# peek cache
+User.cacher.peek_by(id: user_id)
+
+# clean cache
+User.cacher.clean_by(id: user_id)
 ```
 
 Also support caching self by other columns.
 ```rb
 class User < ActiveRecord::Base
-  cache_self, by: :account
+  cache_self by: :account
 end
 
 @user = User.cacher.find_by(account: 'khiav')
+
+# peek cache
+User.cacher.peek_by(account: 'khiav')
+
+# clean cache
+User.cacher.clean_by(account: 'khiav')
 ```
 
 ### Caching Attributes

--- a/lib/active_model_cachers/active_record/cacher.rb
+++ b/lib/active_model_cachers/active_record/cacher.rb
@@ -6,8 +6,9 @@ module ActiveModelCachers
 
       class << self
         def define_cacher_method(attr, primary_key, service_klasses)
-          method = attr.column || (primary_key == :id ? :self : :"self_by_#{primary_key}")
           cacher_klass = get_cacher_klass(attr.klass)
+          method = attr.column
+          return cacher_klass.define_find_by(attr, primary_key, service_klasses) if method == nil
           cacher_klass.attributes << method
           cacher_klass.send(:define_method, method){ exec_by(attr, primary_key, service_klasses, :get) }
           cacher_klass.send(:define_method, "peek_#{method}"){ exec_by(attr, primary_key, service_klasses, :peek) }
@@ -16,6 +17,20 @@ module ActiveModelCachers
 
         def get_cacher_klass(klass)
           @defined_map[klass] ||= create_cacher_klass_at(klass)
+        end
+
+        def define_find_by(attr, primary_key, service_klasses)
+          if @find_by_mapping == nil
+            @find_by_mapping = {}
+            define_method(:find_by){|args| exec_find_by(args, :get) }
+            define_method(:clean_by){|args| exec_find_by(args, :clean_cache) }
+          end
+          @find_by_mapping[primary_key] = [attr, service_klasses]
+        end
+
+        def get_data_from_find_by_mapping(primary_key)
+          return if @find_by_mapping == nil
+          return @find_by_mapping[primary_key]
         end
 
         private
@@ -39,6 +54,13 @@ module ActiveModelCachers
       end
 
       private
+
+      def exec_find_by(args, method) # e.g. args = {course_id: xx}
+        primary_key = args.keys.sort.join(',')
+        attr, service_klasses = self.class.get_data_from_find_by_mapping(primary_key)
+        return if service_klasses == nil
+        return exec_by(attr, primary_key, service_klasses, method)
+      end
 
       def exec_by(attr, primary_key, service_klasses, method)
         bindings = [@model]

--- a/lib/active_model_cachers/active_record/cacher.rb
+++ b/lib/active_model_cachers/active_record/cacher.rb
@@ -23,6 +23,7 @@ module ActiveModelCachers
           if @find_by_mapping == nil
             @find_by_mapping = {}
             define_method(:find_by){|args| exec_find_by(args, :get) }
+            define_method(:peek_by){|args| exec_find_by(args, :peek) }
             define_method(:clean_by){|args| exec_find_by(args, :clean_cache) }
           end
           @find_by_mapping[primary_key] = [attr, service_klasses]

--- a/lib/active_model_cachers/active_record/cacher.rb
+++ b/lib/active_model_cachers/active_record/cacher.rb
@@ -22,6 +22,7 @@ module ActiveModelCachers
         def define_find_by(attr, primary_key, service_klasses)
           if @find_by_mapping == nil
             @find_by_mapping = {}
+            attributes << :find_by
             define_method(:find_by){|args| exec_find_by(args, :get) }
             define_method(:peek_by){|args| exec_find_by(args, :peek) }
             define_method(:clean_by){|args| exec_find_by(args, :clean_cache) }

--- a/lib/active_model_cachers/active_record/cacher.rb
+++ b/lib/active_model_cachers/active_record/cacher.rb
@@ -56,13 +56,13 @@ module ActiveModelCachers
       private
 
       def exec_find_by(args, method) # e.g. args = {course_id: xx}
-        primary_key = args.keys.sort.join(',')
+        primary_key = args.keys.sort.first # Support only one key now.
         attr, service_klasses = self.class.get_data_from_find_by_mapping(primary_key)
         return if service_klasses == nil
-        return exec_by(attr, primary_key, service_klasses, method)
+        return exec_by(attr, primary_key, service_klasses, method, data: args[primary_key])
       end
 
-      def exec_by(attr, primary_key, service_klasses, method)
+      def exec_by(attr, primary_key, service_klasses, method, data: nil)
         bindings = [@model]
         if @model and attr.association?
           if attr.belongs_to? and method != :clean_cache # no need to load binding when just cleaning cache

--- a/lib/active_model_cachers/column_value_cache.rb
+++ b/lib/active_model_cachers/column_value_cache.rb
@@ -38,7 +38,7 @@ class ActiveModelCachers::ColumnValueCache
 
   def get_id_from(object, id, column, model)
     return id if column == 'id'
-    model ||= object.cacher_at(id).peek_self if object.has_cacher?
+    model ||= object.cacher.peek_by(id: id) if object.has_cacher?
     return model.send(column) if model
     return :not_set
   end

--- a/test/cache_bool_data_test.rb
+++ b/test/cache_bool_data_test.rb
@@ -191,8 +191,8 @@ class CacheBoolDataTest < BaseTest
     assert_queries(0){ assert_equal true, User.cacher_at(user.id).has_post? }
     assert_cache("active_model_cachers_User_at_has_post?_#{user.id}" => true)
 
-    assert_queries(1){ assert_equal post, Post.cacher_at(post.id).self }
-    assert_queries(0){ assert_equal post, Post.cacher_at(post.id).self }
+    assert_queries(1){ assert_equal post, Post.cacher.find_by(id: post.id) }
+    assert_queries(0){ assert_equal post, Post.cacher.find_by(id: post.id) }
     assert_cache("active_model_cachers_User_at_has_post?_#{user.id}" => true, "active_model_cachers_Post_#{post.id}" => post)
 
     assert_queries(1){ Post.delete(-2) } # 1: select post.user_id from Post.cache_self to clean cache on user.posts. 2: delete post.

--- a/test/cache_self_by_other_column_test.rb
+++ b/test/cache_self_by_other_column_test.rb
@@ -5,11 +5,11 @@ class CacheSelfByOtherColumnTest < BaseTest
   def test_basic_usage
     profile = User.find_by(name: 'John2').profile
 
-    assert_queries(1){ assert_equal 10, Profile.cacher_at('tt9wav').self_by_token.point }
-    assert_queries(0){ assert_equal 10, Profile.cacher_at('tt9wav').self_by_token.point }
+    assert_queries(1){ assert_equal 10, Profile.cacher.find_by(token: 'tt9wav').point }
+    assert_queries(0){ assert_equal 10, Profile.cacher.find_by(token: 'tt9wav').point }
     assert_cache('active_model_cachers_Profile_by_token_tt9wav' => profile)
 
-    assert_queries(0){ assert_equal 10, Profile.cacher_at('tt9wav').self_by_token.point }
+    assert_queries(0){ assert_equal 10, Profile.cacher.find_by(token: 'tt9wav').point }
     assert_cache('active_model_cachers_Profile_by_token_tt9wav' => profile)
   end
 
@@ -19,15 +19,15 @@ class CacheSelfByOtherColumnTest < BaseTest
   def test_create
     profile = nil
 
-    assert_queries(1){ assert_nil Profile.cacher_at('a').self_by_token }
-    assert_queries(0){ assert_nil Profile.cacher_at('a').self_by_token }
+    assert_queries(1){ assert_nil Profile.cacher.find_by(token: 'a') }
+    assert_queries(0){ assert_nil Profile.cacher.find_by(token: 'a') }
     assert_cache('active_model_cachers_Profile_by_token_a' => ActiveModelCachers::NilObject)
 
     assert_queries(1){ profile = Profile.create(id: -1, point: 3, token: 'a') }
     assert_cache({})
 
-    assert_queries(1){ assert_equal 3, Profile.cacher_at('a').self_by_token.point }
-    assert_queries(0){ assert_equal 3, Profile.cacher_at('a').self_by_token.point }
+    assert_queries(1){ assert_equal 3, Profile.cacher.find_by(token: 'a').point }
+    assert_queries(0){ assert_equal 3, Profile.cacher.find_by(token: 'a').point }
     assert_cache('active_model_cachers_Profile_by_token_a' => profile)
   ensure
     profile.destroy if profile
@@ -42,7 +42,7 @@ class CacheSelfByOtherColumnTest < BaseTest
     Rails.cache.write('active_model_cachers_Profile_by_token_tt9wav', profile)
     assert_cache('active_model_cachers_Profile_by_token_tt9wav' => profile)
 
-    assert_queries(0){ Profile.cacher_at('tt9wav').clean_self_by_token }
+    assert_queries(0){ Profile.cacher.clean_by(token: 'tt9wav') }
     assert_cache({})
   end
 
@@ -52,7 +52,7 @@ class CacheSelfByOtherColumnTest < BaseTest
     Rails.cache.write('active_model_cachers_Profile_by_token_tt9wav', profile)
     assert_cache('active_model_cachers_Profile_by_token_tt9wav' => profile)
 
-    assert_queries(0){ Profile.cacher_at('tt9wav').clean(:self_by_token) }
+    assert_queries(0){ Profile.cacher.clean_by(token: 'tt9wav') }
     assert_cache({})
   end
 
@@ -62,29 +62,29 @@ class CacheSelfByOtherColumnTest < BaseTest
   def test_update_nothing
     profile = User.find_by(name: 'John2').profile
 
-    assert_queries(1){ assert_equal 10, Profile.cacher_at('tt9wav').self_by_token.point }
-    assert_queries(0){ assert_equal 10, Profile.cacher_at('tt9wav').self_by_token.point }
+    assert_queries(1){ assert_equal 10, Profile.cacher.find_by(token: 'tt9wav').point }
+    assert_queries(0){ assert_equal 10, Profile.cacher.find_by(token: 'tt9wav').point }
     assert_cache('active_model_cachers_Profile_by_token_tt9wav' => profile)
 
     assert_queries(0){ profile.save }
     assert_cache('active_model_cachers_Profile_by_token_tt9wav' => profile)
 
-    assert_queries(0){ assert_equal 10, Profile.cacher_at('tt9wav').self_by_token.point }
+    assert_queries(0){ assert_equal 10, Profile.cacher.find_by(token: 'tt9wav').point }
     assert_cache('active_model_cachers_Profile_by_token_tt9wav' => profile)
   end
 
   def test_update
     profile = User.find_by(name: 'John2').profile
 
-    assert_queries(1){ assert_equal 10, Profile.cacher_at('tt9wav').self_by_token.point }
-    assert_queries(0){ assert_equal 10, Profile.cacher_at('tt9wav').self_by_token.point }
+    assert_queries(1){ assert_equal 10, Profile.cacher.find_by(token: 'tt9wav').point }
+    assert_queries(0){ assert_equal 10, Profile.cacher.find_by(token: 'tt9wav').point }
     assert_cache('active_model_cachers_Profile_by_token_tt9wav' => profile)
 
     assert_queries(1){ profile.update_attributes(point: 12) }
     assert_cache({})
 
-    assert_queries(1){ assert_equal 12, Profile.cacher_at('tt9wav').self_by_token.point }
-    assert_queries(0){ assert_equal 12, Profile.cacher_at('tt9wav').self_by_token.point }
+    assert_queries(1){ assert_equal 12, Profile.cacher.find_by(token: 'tt9wav').point }
+    assert_queries(0){ assert_equal 12, Profile.cacher.find_by(token: 'tt9wav').point }
     assert_cache('active_model_cachers_Profile_by_token_tt9wav' => profile)
   ensure
     profile.update_attributes(point: 10)
@@ -96,15 +96,15 @@ class CacheSelfByOtherColumnTest < BaseTest
   def test_destroy
     profile = Profile.create(point: 13, token: 'a')
 
-    assert_queries(1){ assert_equal 13, Profile.cacher_at('a').self_by_token.point }
-    assert_queries(0){ assert_equal 13, Profile.cacher_at('a').self_by_token.point }
+    assert_queries(1){ assert_equal 13, Profile.cacher.find_by(token: 'a').point }
+    assert_queries(0){ assert_equal 13, Profile.cacher.find_by(token: 'a').point }
     assert_cache('active_model_cachers_Profile_by_token_a' => profile)
 
     assert_queries(1){ profile.destroy }
     assert_cache({})
 
-    assert_queries(1){ assert_nil Profile.cacher_at('a').self_by_token }
-    assert_queries(0){ assert_nil Profile.cacher_at('a').self_by_token }
+    assert_queries(1){ assert_nil Profile.cacher.find_by(token: 'a') }
+    assert_queries(0){ assert_nil Profile.cacher.find_by(token: 'a') }
     assert_cache('active_model_cachers_Profile_by_token_a' => ActiveModelCachers::NilObject)
   ensure
     profile.destroy
@@ -116,15 +116,15 @@ class CacheSelfByOtherColumnTest < BaseTest
   def test_delete
     profile = Profile.create(point: 13, token: 'a')
 
-    assert_queries(1){ assert_equal 13, Profile.cacher_at('a').self_by_token.point }
-    assert_queries(0){ assert_equal 13, Profile.cacher_at('a').self_by_token.point }
+    assert_queries(1){ assert_equal 13, Profile.cacher.find_by(token: 'a').point }
+    assert_queries(0){ assert_equal 13, Profile.cacher.find_by(token: 'a').point }
     assert_cache('active_model_cachers_Profile_by_token_a' => profile)
 
     assert_queries(1){ profile.delete }
     assert_cache({})
 
-    assert_queries(1){ assert_nil Profile.cacher_at('a').self_by_token }
-    assert_queries(0){ assert_nil Profile.cacher_at('a').self_by_token }
+    assert_queries(1){ assert_nil Profile.cacher.find_by(token: 'a') }
+    assert_queries(0){ assert_nil Profile.cacher.find_by(token: 'a') }
     assert_cache('active_model_cachers_Profile_by_token_a' => ActiveModelCachers::NilObject)
   ensure
     profile.delete
@@ -134,15 +134,15 @@ class CacheSelfByOtherColumnTest < BaseTest
     profile = Profile.create(point: 17, token: 'a')
     user = User.create(profile: profile)
 
-    assert_queries(1){ assert_equal 17, Profile.cacher_at('a').self_by_token.point }
-    assert_queries(0){ assert_equal 17, Profile.cacher_at('a').self_by_token.point }
+    assert_queries(1){ assert_equal 17, Profile.cacher.find_by(token: 'a').point }
+    assert_queries(0){ assert_equal 17, Profile.cacher.find_by(token: 'a').point }
     assert_cache('active_model_cachers_Profile_by_token_a' => profile)
 
     user.destroy
     assert_cache({})
 
-    assert_queries(1){ assert_nil Profile.cacher_at('a').self_by_token }
-    assert_queries(0){ assert_nil Profile.cacher_at('a').self_by_token }
+    assert_queries(1){ assert_nil Profile.cacher.find_by(token: 'a') }
+    assert_queries(0){ assert_nil Profile.cacher.find_by(token: 'a') }
     assert_cache('active_model_cachers_Profile_by_token_a' => ActiveModelCachers::NilObject)
   ensure
     user.destroy
@@ -152,19 +152,19 @@ class CacheSelfByOtherColumnTest < BaseTest
     profile = Profile.create(id: -1, point: 7, token: 'a')
     difficulty = Difficulty.create(id: -1, level: 4, description: 'vary hard')
 
-    assert_queries(1){ assert_equal 7, Profile.cacher_at('a').self_by_token.point }
-    assert_queries(0){ assert_equal 7, Profile.cacher_at('a').self_by_token.point }
-    assert_queries(1){ assert_equal 4, Difficulty.cacher_at(difficulty.id).self.level }
-    assert_queries(0){ assert_equal 4, Difficulty.cacher_at(difficulty.id).self.level }
+    assert_queries(1){ assert_equal 7, Profile.cacher.find_by(token: 'a').point }
+    assert_queries(0){ assert_equal 7, Profile.cacher.find_by(token: 'a').point }
+    assert_queries(1){ assert_equal 4, Difficulty.cacher.find_by(id: difficulty.id).self.level }
+    assert_queries(0){ assert_equal 4, Difficulty.cacher.find_by(id: difficulty.id).self.level }
     assert_cache('active_model_cachers_Profile_by_token_a' => profile, 'active_model_cachers_Difficulty_-1' => difficulty)
 
     # delete difficulty with id = -1 should not clean the cache of profile with same id.
     difficulty.delete
     assert_cache('active_model_cachers_Profile_by_token_a' => profile)
 
-    assert_queries(0){ assert_equal 7, Profile.cacher_at('a').self_by_token.point }
-    assert_queries(1){ assert_nil Difficulty.cacher_at(difficulty.id).self }
-    assert_queries(0){ assert_nil Difficulty.cacher_at(difficulty.id).self }
+    assert_queries(0){ assert_equal 7, Profile.cacher.find_by(token: 'a').point }
+    assert_queries(1){ assert_nil Difficulty.cacher.find_by(id: difficulty.id).self }
+    assert_queries(0){ assert_nil Difficulty.cacher.find_by(id: difficulty.id).self }
     assert_cache('active_model_cachers_Profile_by_token_a' => profile, 'active_model_cachers_Difficulty_-1' => ActiveModelCachers::NilObject)
   ensure
     profile.delete

--- a/test/cache_self_by_other_column_test.rb
+++ b/test/cache_self_by_other_column_test.rb
@@ -154,8 +154,8 @@ class CacheSelfByOtherColumnTest < BaseTest
 
     assert_queries(1){ assert_equal 7, Profile.cacher.find_by(token: 'a').point }
     assert_queries(0){ assert_equal 7, Profile.cacher.find_by(token: 'a').point }
-    assert_queries(1){ assert_equal 4, Difficulty.cacher.find_by(id: difficulty.id).self.level }
-    assert_queries(0){ assert_equal 4, Difficulty.cacher.find_by(id: difficulty.id).self.level }
+    assert_queries(1){ assert_equal 4, Difficulty.cacher.find_by(id: difficulty.id).level }
+    assert_queries(0){ assert_equal 4, Difficulty.cacher.find_by(id: difficulty.id).level }
     assert_cache('active_model_cachers_Profile_by_token_a' => profile, 'active_model_cachers_Difficulty_-1' => difficulty)
 
     # delete difficulty with id = -1 should not clean the cache of profile with same id.
@@ -163,8 +163,8 @@ class CacheSelfByOtherColumnTest < BaseTest
     assert_cache('active_model_cachers_Profile_by_token_a' => profile)
 
     assert_queries(0){ assert_equal 7, Profile.cacher.find_by(token: 'a').point }
-    assert_queries(1){ assert_nil Difficulty.cacher.find_by(id: difficulty.id).self }
-    assert_queries(0){ assert_nil Difficulty.cacher.find_by(id: difficulty.id).self }
+    assert_queries(1){ assert_nil Difficulty.cacher.find_by(id: difficulty.id) }
+    assert_queries(0){ assert_nil Difficulty.cacher.find_by(id: difficulty.id) }
     assert_cache('active_model_cachers_Profile_by_token_a' => profile, 'active_model_cachers_Difficulty_-1' => ActiveModelCachers::NilObject)
   ensure
     profile.delete

--- a/test/cache_self_test.rb
+++ b/test/cache_self_test.rb
@@ -143,7 +143,7 @@ class CacheSelfTest < BaseTest
     difficulty = Difficulty.create(level: 4, description: 'vary hard')
 
     # make sure Difficulty only have cache_self, and doesn't cache by other models by something like cache_at :difficulty
-    assert_equal [:self], Difficulty.cacher.class.attributes
+    assert_equal [:find_by], Difficulty.cacher.class.attributes
     assert_equal 2, Difficulty.before_delete_hooks.size
 
     assert_queries(1){ assert_equal 4, Difficulty.cacher.find_by(id: difficulty.id).level }

--- a/test/cache_self_test.rb
+++ b/test/cache_self_test.rb
@@ -94,8 +94,8 @@ class CacheSelfTest < BaseTest
     assert_queries(1){ profile.destroy }
     assert_cache({})
 
-    assert_queries(1){ assert_nil User.cacher.find_by(id: -11).profile }
-    assert_queries(0){ assert_nil User.cacher.find_by(id: -11).profile }
+    assert_queries(1){ assert_nil User.cacher_at(-11).profile }
+    assert_queries(0){ assert_nil User.cacher_at(-11).profile }
     assert_cache('active_model_cachers_Profile_by_user_id_-11' => ActiveModelCachers::NilObject)
   ensure
     profile.destroy

--- a/test/cache_self_test.rb
+++ b/test/cache_self_test.rb
@@ -5,11 +5,11 @@ class CacheSelfTest < BaseTest
   def test_basic_usage
     profile = User.find_by(name: 'John2').profile
 
-    assert_queries(1){ assert_equal 10, Profile.cacher_at(profile.id).self.point }
-    assert_queries(0){ assert_equal 10, Profile.cacher_at(profile.id).self.point }
+    assert_queries(1){ assert_equal 10, Profile.cacher.find_by(id:profile.id).point }
+    assert_queries(0){ assert_equal 10, Profile.cacher.find_by(id:profile.id).point }
     assert_cache('active_model_cachers_Profile_1' => profile)
 
-    assert_queries(0){ assert_equal 10, Profile.cacher_at(profile.id).self.point }
+    assert_queries(0){ assert_equal 10, Profile.cacher.find_by(id:profile.id).point }
     assert_cache('active_model_cachers_Profile_1' => profile)
   end
 
@@ -19,15 +19,15 @@ class CacheSelfTest < BaseTest
   def test_create
     profile = nil
 
-    assert_queries(1){ assert_nil Profile.cacher_at(-1).self }
-    assert_queries(0){ assert_nil Profile.cacher_at(-1).self }
+    assert_queries(1){ assert_nil Profile.cacher.find_by(id:-1) }
+    assert_queries(0){ assert_nil Profile.cacher.find_by(id:-1) }
     assert_cache('active_model_cachers_Profile_-1' => ActiveModelCachers::NilObject)
 
     assert_queries(1){ profile = Profile.create(id: -1, point: 3) }
     assert_cache({})
 
-    assert_queries(1){ assert_equal 3, Profile.cacher_at(-1).self.point }
-    assert_queries(0){ assert_equal 3, Profile.cacher_at(-1).self.point }
+    assert_queries(1){ assert_equal 3, Profile.cacher.find_by(id:-1).point }
+    assert_queries(0){ assert_equal 3, Profile.cacher.find_by(id:-1).point }
     assert_cache('active_model_cachers_Profile_-1' => profile)
   ensure
     profile.destroy if profile
@@ -36,23 +36,14 @@ class CacheSelfTest < BaseTest
   # ----------------------------------------------------------------
   # ● Clean
   # ----------------------------------------------------------------
+
   def test_clean
     profile = User.find_by(name: 'John2').profile
 
     Rails.cache.write('active_model_cachers_Profile_1', profile)
     assert_cache('active_model_cachers_Profile_1' => profile)
 
-    assert_queries(0){ Profile.cacher_at(profile.id).clean_self }
-    assert_cache({})
-  end
-
-  def test_clean2
-    profile = User.find_by(name: 'John2').profile
-
-    Rails.cache.write('active_model_cachers_Profile_1', profile)
-    assert_cache('active_model_cachers_Profile_1' => profile)
-
-    assert_queries(0){ Profile.cacher_at(profile.id).clean(:self) }
+    assert_queries(0){ Profile.cacher.clean_by(id: profile.id) }
     assert_cache({})
   end
 
@@ -62,29 +53,29 @@ class CacheSelfTest < BaseTest
   def test_update_nothing
     profile = User.find_by(name: 'John2').profile
 
-    assert_queries(1){ assert_equal 10, Profile.cacher_at(profile.id).self.point }
-    assert_queries(0){ assert_equal 10, Profile.cacher_at(profile.id).self.point }
+    assert_queries(1){ assert_equal 10, Profile.cacher.find_by(id: profile.id).point }
+    assert_queries(0){ assert_equal 10, Profile.cacher.find_by(id: profile.id).point }
     assert_cache('active_model_cachers_Profile_1' => profile)
 
     assert_queries(0){ profile.save }
     assert_cache('active_model_cachers_Profile_1' => profile)
 
-    assert_queries(0){ assert_equal 10, Profile.cacher_at(profile.id).self.point }
+    assert_queries(0){ assert_equal 10, Profile.cacher.find_by(id: profile.id).point }
     assert_cache('active_model_cachers_Profile_1' => profile)
   end
 
   def test_update
     profile = User.find_by(name: 'John2').profile
 
-    assert_queries(1){ assert_equal 10, Profile.cacher_at(profile.id).self.point }
-    assert_queries(0){ assert_equal 10, Profile.cacher_at(profile.id).self.point }
+    assert_queries(1){ assert_equal 10, Profile.cacher.find_by(id: profile.id).point }
+    assert_queries(0){ assert_equal 10, Profile.cacher.find_by(id: profile.id).point }
     assert_cache('active_model_cachers_Profile_1' => profile)
 
     assert_queries(1){ profile.update_attributes(point: 12) }
     assert_cache({})
 
-    assert_queries(1){ assert_equal 12, Profile.cacher_at(profile.id).self.point }
-    assert_queries(0){ assert_equal 12, Profile.cacher_at(profile.id).self.point }
+    assert_queries(1){ assert_equal 12, Profile.cacher.find_by(id: profile.id).point }
+    assert_queries(0){ assert_equal 12, Profile.cacher.find_by(id: profile.id).point }
     assert_cache('active_model_cachers_Profile_1' => profile)
   ensure
     profile.update_attributes(point: 10)
@@ -96,15 +87,15 @@ class CacheSelfTest < BaseTest
   def test_destroy
     profile = Profile.create(id: -3, user_id: -11, point: 13)
 
-    assert_queries(1){ assert_equal 13, Profile.cacher_at(-3).self.point }
-    assert_queries(0){ assert_equal 13, Profile.cacher_at(-3).self.point }
+    assert_queries(1){ assert_equal 13, Profile.cacher.find_by(id: -3).point }
+    assert_queries(0){ assert_equal 13, Profile.cacher.find_by(id: -3).point }
     assert_cache('active_model_cachers_Profile_-3' => profile)
 
     assert_queries(1){ profile.destroy }
     assert_cache({})
 
-    assert_queries(1){ assert_nil User.cacher_at(-11).profile }
-    assert_queries(0){ assert_nil User.cacher_at(-11).profile }
+    assert_queries(1){ assert_nil User.cacher.find_by(id: -11).profile }
+    assert_queries(0){ assert_nil User.cacher.find_by(id: -11).profile }
     assert_cache('active_model_cachers_Profile_by_user_id_-11' => ActiveModelCachers::NilObject)
   ensure
     profile.destroy
@@ -116,15 +107,15 @@ class CacheSelfTest < BaseTest
   def test_delete
     profile = Profile.create(point: 13)
 
-    assert_queries(1){ assert_equal 13, Profile.cacher_at(profile.id).self.point }
-    assert_queries(0){ assert_equal 13, Profile.cacher_at(profile.id).self.point }
+    assert_queries(1){ assert_equal 13, Profile.cacher.find_by(id: profile.id).point }
+    assert_queries(0){ assert_equal 13, Profile.cacher.find_by(id: profile.id).point }
     assert_cache("active_model_cachers_Profile_#{profile.id}" => profile)
 
     assert_queries(1){ profile.delete }
     assert_cache({})
 
-    assert_queries(1){ assert_nil Profile.cacher_at(profile.id).self }
-    assert_queries(0){ assert_nil Profile.cacher_at(profile.id).self }
+    assert_queries(1){ assert_nil Profile.cacher.find_by(id: profile.id) }
+    assert_queries(0){ assert_nil Profile.cacher.find_by(id: profile.id) }
     assert_cache("active_model_cachers_Profile_#{profile.id}" => ActiveModelCachers::NilObject)
   ensure
     profile.delete
@@ -134,15 +125,15 @@ class CacheSelfTest < BaseTest
     profile = Profile.create(point: 17)
     user = User.create(profile: profile)
 
-    assert_queries(1){ assert_equal 17, Profile.cacher_at(profile.id).self.point }
-    assert_queries(0){ assert_equal 17, Profile.cacher_at(profile.id).self.point }
+    assert_queries(1){ assert_equal 17, Profile.cacher.find_by(id: profile.id).point }
+    assert_queries(0){ assert_equal 17, Profile.cacher.find_by(id: profile.id).point }
     assert_cache("active_model_cachers_Profile_#{profile.id}" => profile)
 
     user.destroy
     assert_cache({})
 
-    assert_queries(1){ assert_nil Profile.cacher_at(profile.id).self }
-    assert_queries(0){ assert_nil Profile.cacher_at(profile.id).self }
+    assert_queries(1){ assert_nil Profile.cacher.find_by(id: profile.id) }
+    assert_queries(0){ assert_nil Profile.cacher.find_by(id: profile.id) }
     assert_cache("active_model_cachers_Profile_#{profile.id}" => ActiveModelCachers::NilObject)
   ensure
     user.destroy
@@ -155,15 +146,15 @@ class CacheSelfTest < BaseTest
     assert_equal [:self], Difficulty.cacher.class.attributes
     assert_equal 2, Difficulty.before_delete_hooks.size
 
-    assert_queries(1){ assert_equal 4, Difficulty.cacher_at(difficulty.id).self.level }
-    assert_queries(0){ assert_equal 4, Difficulty.cacher_at(difficulty.id).self.level }
+    assert_queries(1){ assert_equal 4, Difficulty.cacher.find_by(id: difficulty.id).level }
+    assert_queries(0){ assert_equal 4, Difficulty.cacher.find_by(id: difficulty.id).level }
     assert_cache("active_model_cachers_Difficulty_#{difficulty.id}" => difficulty)
 
     difficulty.delete
     assert_cache({})
 
-    assert_queries(1){ assert_nil Difficulty.cacher_at(difficulty.id).self }
-    assert_queries(0){ assert_nil Difficulty.cacher_at(difficulty.id).self }
+    assert_queries(1){ assert_nil Difficulty.cacher.find_by(id: difficulty.id) }
+    assert_queries(0){ assert_nil Difficulty.cacher.find_by(id: difficulty.id) }
     assert_cache("active_model_cachers_Difficulty_#{difficulty.id}" => ActiveModelCachers::NilObject)
   ensure
     difficulty.delete
@@ -173,19 +164,19 @@ class CacheSelfTest < BaseTest
     profile = Profile.create(id: -1, point: 7)
     difficulty = Difficulty.create(id: -1, level: 4, description: 'vary hard')
 
-    assert_queries(1){ assert_equal 7, Profile.cacher_at(profile.id).self.point }
-    assert_queries(0){ assert_equal 7, Profile.cacher_at(profile.id).self.point }
-    assert_queries(1){ assert_equal 4, Difficulty.cacher_at(difficulty.id).self.level }
-    assert_queries(0){ assert_equal 4, Difficulty.cacher_at(difficulty.id).self.level }
+    assert_queries(1){ assert_equal 7, Profile.cacher.find_by(id: profile.id).point }
+    assert_queries(0){ assert_equal 7, Profile.cacher.find_by(id: profile.id).point }
+    assert_queries(1){ assert_equal 4, Difficulty.cacher.find_by(id: difficulty.id).level }
+    assert_queries(0){ assert_equal 4, Difficulty.cacher.find_by(id: difficulty.id).level }
     assert_cache('active_model_cachers_Profile_-1' => profile, 'active_model_cachers_Difficulty_-1' => difficulty)
 
     # delete difficulty with id = -1 should not clean the cache of profile with same id.
     difficulty.delete
     assert_cache('active_model_cachers_Profile_-1' => profile)
 
-    assert_queries(0){ assert_equal 7, Profile.cacher_at(profile.id).self.point }
-    assert_queries(1){ assert_nil Difficulty.cacher_at(difficulty.id).self }
-    assert_queries(0){ assert_nil Difficulty.cacher_at(difficulty.id).self }
+    assert_queries(0){ assert_equal 7, Profile.cacher.find_by(id: profile.id).point }
+    assert_queries(1){ assert_nil Difficulty.cacher.find_by(id: difficulty.id) }
+    assert_queries(0){ assert_nil Difficulty.cacher.find_by(id: difficulty.id) }
     assert_cache('active_model_cachers_Profile_-1' => profile, 'active_model_cachers_Difficulty_-1' => ActiveModelCachers::NilObject)
   ensure
     profile.delete

--- a/test/instance_scope_test.rb
+++ b/test/instance_scope_test.rb
@@ -164,8 +164,8 @@ class InstanceScopeTest < BaseTest
     assert_queries(0){ assert_equal true, user.cacher.has_post2? }
     assert_cache("active_model_cachers_User_at_has_post2?_#{user.id}" => true)
 
-    assert_queries(1){ assert_equal post, Post.cacher_at(post.id).self }
-    assert_queries(0){ assert_equal post, Post.cacher_at(post.id).self }
+    assert_queries(1){ assert_equal post, Post.cacher.find_by(id: post.id) }
+    assert_queries(0){ assert_equal post, Post.cacher.find_by(id: post.id) }
     assert_cache("active_model_cachers_User_at_has_post2?_#{user.id}" => true, "active_model_cachers_Post_#{post.id}" => post)
 
     assert_queries(1){ Post.delete(-2) } # 1: select post.user_id from Post.cache_self to clean cache on user.posts. 2: delete post.


### PR DESCRIPTION
Use the `find_by` syntax here: https://github.com/khiav223577/active_model_cachers/issues/30, since it is at lease better than current syntax. Farther discussion is still welcome :)