### PR TITLE
Preventing registering same callbacks in some cases

### DIFF
--- a/lib/active_model_cachers/active_record/extension.rb
+++ b/lib/active_model_cachers/active_record/extension.rb
@@ -20,13 +20,11 @@ module ActiveModelCachers
         service_klass = CacheServiceFactory.create_for_active_model(attr, query)
         Cacher.define_cacher_method(attr, attr.primary_key || :id, [service_klass])
 
-        with_id = true if expire_by.is_a?(Symbol) or query.parameters.size == 1
-        expire_class, expire_column, foreign_key = get_expire_infos(attr, expire_by, foreign_key)
-        if expire_class
-          service_klass.define_callback_for_cleaning_cache(expire_class, expire_column, foreign_key, on: on) do |id|
-            service_klass.clean_at(with_id ? id : nil)
-          end
+        if (infos = get_expire_infos(attr, expire_by, foreign_key))
+          with_id = (expire_by.is_a?(Symbol) || query.parameters.size == 1)
+          service_klass.define_callback_for_cleaning_cache(*infos, with_id, on: on)
         end
+
         return service_klass
       end
 

--- a/lib/active_model_cachers/cache_service.rb
+++ b/lib/active_model_cachers/cache_service.rb
@@ -19,7 +19,9 @@ module ActiveModelCachers
       end
 
       @@column_value_cache = ActiveModelCachers::ColumnValueCache.new
-      def define_callback_for_cleaning_cache(class_name, column, foreign_key, on: nil, &clean)
+      def define_callback_for_cleaning_cache(class_name, column, foreign_key, with_id, on: nil)
+        clean = ->(id){ clean_at(with_id ? id : nil) }
+
         ActiveSupport::Dependencies.onload(class_name) do
           clean_ids = []
 

--- a/lib/active_model_cachers/cache_service.rb
+++ b/lib/active_model_cachers/cache_service.rb
@@ -20,6 +20,9 @@ module ActiveModelCachers
 
       @@column_value_cache = ActiveModelCachers::ColumnValueCache.new
       def define_callback_for_cleaning_cache(class_name, column, foreign_key, with_id, on: nil)
+        return if @callbacks_defined
+        @callbacks_defined = true
+
         clean = ->(id){ clean_at(with_id ? id : nil) }
 
         ActiveSupport::Dependencies.onload(class_name) do
@@ -35,7 +38,7 @@ module ActiveModelCachers
           end
 
           after_delete do
-            @@column_value_cache.clean_cache()
+            @@column_value_cache.clean_cache
           end
 
           on_nullify(column){|ids| ids.each{|s| clean.call(s) }}

--- a/lib/active_model_cachers/cache_service_factory.rb
+++ b/lib/active_model_cachers/cache_service_factory.rb
@@ -22,6 +22,7 @@ module ActiveModelCachers
           klass = Class.new(CacheService)
           klass.cache_key = cache_key
           klass.query = query
+          klass.instance_variable_set(:@callbacks_defined, false) # to remove warning: instance variable @callbacks_defined not initialized
           next klass
         }[]
       end

--- a/test/lib/models/shared_cache.rb
+++ b/test/lib/models/shared_cache.rb
@@ -1,0 +1,5 @@
+module SharedCache
+  def self.table_name_prefix
+    'shared_cache_'
+  end
+end

--- a/test/lib/models/shared_cache/profile.rb
+++ b/test/lib/models/shared_cache/profile.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class SharedCache::Profile < ActiveRecord::Base
+  belongs_to :user, class_name: 'SharedCache::User'
+
+  cache_self by: :user_id
+end

--- a/test/lib/models/shared_cache/user.rb
+++ b/test/lib/models/shared_cache/user.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class SharedCache::User < ActiveRecord::Base
+  has_one :profile, class_name: 'SharedCache::Profile'
+
+  cache_at :profile
+end

--- a/test/lib/rails_cache.rb
+++ b/test/lib/rails_cache.rb
@@ -14,10 +14,12 @@ module Rails
 
     def read(key)
       return nil if not exist?(key)
+      ActiveSupport::Notifications.instrument('cache.active_record', sql: "Read cache at #{key}")
       return Marshal.load(@cache[key][:data])
     end
 
     def delete(key)
+      ActiveSupport::Notifications.instrument('cache.active_record', sql: "Delete cache at #{key}")
       @cache.delete(key)
     end
 
@@ -29,6 +31,7 @@ module Rails
     end
 
     def write(key, val, options = {})
+      ActiveSupport::Notifications.instrument('cache.active_record', sql: "write cache at #{key} with val: #{val}")
       @cache[key] ||= { data: Marshal.dump(val), expired_at: Time.now + 30.minutes }
       return val
     end

--- a/test/lib/seeds.rb
+++ b/test/lib/seeds.rb
@@ -53,6 +53,15 @@ ActiveRecord::Schema.define do
     t.string :name
     t.integer :atk_power
   end
+
+  create_table :shared_cache_users, :force => true do |t|
+    t.string :name
+  end
+
+  create_table :shared_cache_profiles, :force => true do |t|
+    t.integer :user_id
+    t.integer :point
+  end
 end
 
 ActiveSupport::Dependencies.autoload_paths << File.expand_path('../models/', __FILE__)
@@ -130,4 +139,13 @@ Difficulty.create([
   {:level => 1, :description => 'easy'},
   {:level => 2, :description => 'normal'},
   {:level => 3, :description => 'hard'},
+])
+
+shared_cache_users = SharedCache::User.create([
+  {name: 'Pearl'},
+  {name: 'Khiav'},
+])
+
+shared_cache_profiles = SharedCache::Profile.create([
+  {user_id: shared_cache_users[0].id, point: 19},
 ])

--- a/test/shared_cache_test.rb
+++ b/test/shared_cache_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'base_test'
+
+class SharedCacheTest < BaseTest
+  def test_update
+    user = SharedCache::User.first
+
+    assert_queries(1){ assert_equal 19, user.cacher.profile.point }
+    assert_queries(0){ assert_equal 19, user.cacher.profile.point }
+    assert_cache('active_model_cachers_SharedCache::Profile_by_user_id_1' => user.profile)
+
+    assert_cache_queries(1) do
+      assert_queries(1){ user.profile.update_attributes(point: 12) }
+    end
+    assert_cache({})
+
+    user = SharedCache::User.first
+    assert_queries(1){ assert_equal 12, user.cacher.profile.point }
+    assert_queries(0){ assert_equal 12, user.cacher.profile.point }
+    assert_cache('active_model_cachers_SharedCache::Profile_by_user_id_1' => user.profile)
+  ensure
+    user.profile.update_attributes(point: 19)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,9 +19,9 @@ end
 require 'lib/rails_cache'
 require 'lib/seeds'
 
-def assert_queries(expected_count)
+def assert_queries(expected_count, event_key = 'sql.active_record')
   sqls = []
-  subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |_, _, _, _, payload|
+  subscriber = ActiveSupport::Notifications.subscribe(event_key) do |_, _, _, _, payload|
     sqls << "  ● #{payload[:sql]}" if payload[:sql] !~ /\A(?:BEGIN TRANSACTION|COMMIT TRANSACTION)/i
   end
   yield
@@ -35,4 +35,8 @@ end
 
 def assert_cache(data)
   assert_equal(data, Rails.cache.all_data)
+end
+
+def assert_cache_queries(expected_count, &block)
+  assert_queries(expected_count, 'cache.active_record', &block)
 end


### PR DESCRIPTION
In previous implement, the gem will use same service if cache key is the same , see: https://github.com/khiav223577/active_model_cachers/commit/91d8d53c4a383b2fcd25d7ada1dae3b574351279

For example
```rb
class Profile < ActiveRecord::Base
  cache_self by: :user_id
end 

class User < ActiveRecord::Base
  has_one :profile

  cache_at :profile
end
```

Through there are two `cachers`, but the `cache_key` is the same, so they share same `cache_service` object to reduce cache writes. But the callbacks are not shared, causing the same callback being called twice, and cache being cleaned twice.

