### PR TITLE
Fix: ModelName cant be referred to in development

### DIFF
--- a/lib/active_model_cachers/active_record/attr_model.rb
+++ b/lib/active_model_cachers/active_record/attr_model.rb
@@ -72,6 +72,11 @@ module ActiveModelCachers
         return query_attribute(binding, id)
       end
 
+      def extract_class_and_column
+        return [class_name, nil] if single_association?
+        return [@klass.to_s, @column]
+      end
+
       private
 
       def query_self(binding, id)

--- a/lib/active_model_cachers/active_record/cacher.rb
+++ b/lib/active_model_cachers/active_record/cacher.rb
@@ -5,37 +5,48 @@ module ActiveModelCachers
       @defined_map = {}
 
       class << self
+        def get_cacher_klass(klass)
+          @defined_map[klass] ||= create_cacher_klass_at(klass)
+        end
+
         def define_cacher_method(attr, primary_key, service_klasses)
           cacher_klass = get_cacher_klass(attr.klass)
           method = attr.column
           return cacher_klass.define_find_by(attr, primary_key, service_klasses) if method == nil
-          cacher_klass.attributes << method
-          cacher_klass.send(:define_method, method){ exec_by(attr, primary_key, service_klasses, :get) }
-          cacher_klass.send(:define_method, "peek_#{method}"){ exec_by(attr, primary_key, service_klasses, :peek) }
-          cacher_klass.send(:define_method, "clean_#{method}"){ exec_by(attr, primary_key, service_klasses, :clean_cache) }
-        end
-
-        def get_cacher_klass(klass)
-          @defined_map[klass] ||= create_cacher_klass_at(klass)
+          cacher_klass.send(:define_methods, method, {
+            method            => ->{ exec_by(attr, primary_key, service_klasses, :get) },
+            "peek_#{method}"  => ->{ exec_by(attr, primary_key, service_klasses, :peek) },
+            "clean_#{method}" => ->{ exec_by(attr, primary_key, service_klasses, :clean_cache) },
+          })
         end
 
         def define_find_by(attr, primary_key, service_klasses)
           if @find_by_mapping == nil
             @find_by_mapping = {}
-            attributes << :find_by
-            define_method(:find_by){|args| exec_find_by(args, :get) }
-            define_method(:peek_by){|args| exec_find_by(args, :peek) }
-            define_method(:clean_by){|args| exec_find_by(args, :clean_cache) }
+            define_methods(:find_by, {
+              :find_by   => ->(args){ exec_find_by(args, :get) },
+              :peek_by   => ->(args){ exec_find_by(args, :peek) },
+              :clean_by  => ->(args){ exec_find_by(args, :clean_cache) },
+            })
           end
           @find_by_mapping[primary_key] = [attr, service_klasses]
+        end
+
+        private
+
+        def define_methods(attribute, methods_mapping)
+          if attributes.include?(attribute)
+            methods_mapping.keys.each{|s| undef_method(s) }
+          else
+            attributes << attribute
+          end
+          methods_mapping.each{|method, block| define_method(method, &block) }
         end
 
         def get_data_from_find_by_mapping(primary_key)
           return if @find_by_mapping == nil
           return @find_by_mapping[primary_key]
         end
-
-        private
 
         def create_cacher_klass_at(target)
           cacher_klass = Class.new(self)
@@ -60,7 +71,7 @@ module ActiveModelCachers
 
       def exec_find_by(args, method) # e.g. args = {course_id: xx}
         primary_key = args.keys.sort.first # Support only one key now.
-        attr, service_klasses = self.class.get_data_from_find_by_mapping(primary_key)
+        attr, service_klasses = self.class.send(:get_data_from_find_by_mapping, primary_key)
         return if service_klasses == nil
         return exec_by(attr, primary_key, service_klasses, method, data: args[primary_key])
       end

--- a/lib/active_model_cachers/active_record/extension.rb
+++ b/lib/active_model_cachers/active_record/extension.rb
@@ -17,7 +17,7 @@ module ActiveModelCachers
         return cache_belongs_to(attr) if attr.belongs_to?
 
         query ||= ->(id){ attr.query_model(self, id) }
-        service_klass = CacheServiceFactory.create_for_active_model(attr, query)
+        service_klass = CacheServiceFactory.create_for_active_model(self, attr, query)
         Cacher.define_cacher_method(attr, attr.primary_key || :id, [service_klass])
 
         if (infos = get_expire_infos(attr, expire_by, foreign_key))

--- a/lib/active_model_cachers/active_record/extension.rb
+++ b/lib/active_model_cachers/active_record/extension.rb
@@ -19,10 +19,7 @@ module ActiveModelCachers
         query ||= ->(id){ attr.query_model(self, id) }
 
         class_name, *infos = get_expire_infos(attr, expire_by, foreign_key)
-
-        ActiveSupport::Dependencies.onload(class_name || self.to_s) do
-          CacheServiceFactory.set_klass_to_mapping(attr, self)
-        end
+        set_klass_to_mapping(attr, class_name)
 
         service_klass = CacheServiceFactory.create_for_active_model(attr, query)
         Cacher.define_cacher_method(attr, attr.primary_key || :id, [service_klass])
@@ -41,6 +38,12 @@ module ActiveModelCachers
       end
 
       private
+
+      def set_klass_to_mapping(attr, class_name)
+        ActiveSupport::Dependencies.onload(class_name || self.to_s) do
+          CacheServiceFactory.set_klass_to_mapping(attr, self)
+        end
+      end
 
       def get_expire_infos(attr, expire_by, foreign_key)
         if expire_by.is_a?(Symbol)

--- a/lib/active_model_cachers/active_record/extension.rb
+++ b/lib/active_model_cachers/active_record/extension.rb
@@ -17,7 +17,7 @@ module ActiveModelCachers
         return cache_belongs_to(attr) if attr.belongs_to?
 
         query ||= ->(id){ attr.query_model(self, id) }
-        service_klass = CacheServiceFactory.create_for_active_model(attr, query, registed?(self))
+        service_klass = CacheServiceFactory.create_for_active_model(attr, query, self)
         Cacher.define_cacher_method(attr, attr.primary_key || :id, [service_klass])
 
         if (infos = get_expire_infos(attr, expire_by, foreign_key))
@@ -68,13 +68,6 @@ module ActiveModelCachers
         ActiveSupport::Dependencies.onload(attr.class_name) do
           service_klasses << cache_self
         end
-      end
-
-      @@registraion_mapping = {}
-      def registed?(key)
-        return true if @@registraion_mapping[key]
-        @@registraion_mapping[key] = true
-        return false
       end
     end
   end

--- a/lib/active_model_cachers/active_record/extension.rb
+++ b/lib/active_model_cachers/active_record/extension.rb
@@ -16,7 +16,6 @@ module ActiveModelCachers
         attr = AttrModel.new(self, column, foreign_key: foreign_key, primary_key: primary_key)
         return cache_belongs_to(attr) if attr.belongs_to?
 
-        query ||= ->(id){ attr.query_model(self, id) }
         loaded = false
         class_name, *infos = get_expire_infos(attr, expire_by, foreign_key)
         set_klass_to_mapping(attr, class_name) do
@@ -46,7 +45,7 @@ module ActiveModelCachers
 
       def set_klass_to_mapping(attr, class_name)
         ActiveSupport::Dependencies.onload(class_name || self.to_s) do
-          CacheServiceFactory.set_klass_to_mapping(attr, self)
+          yield if CacheServiceFactory.set_klass_to_mapping(attr, self)
         end
       end
 

--- a/lib/active_model_cachers/active_record/extension.rb
+++ b/lib/active_model_cachers/active_record/extension.rb
@@ -72,7 +72,7 @@ module ActiveModelCachers
 
       @@registraion_mapping = {}
       def registed?(key)
-        return true if  @@registraion_mapping[key]
+        return true if @@registraion_mapping[key]
         @@registraion_mapping[key] = true
         return false
       end

--- a/lib/active_model_cachers/active_record/extension.rb
+++ b/lib/active_model_cachers/active_record/extension.rb
@@ -17,7 +17,7 @@ module ActiveModelCachers
         return cache_belongs_to(attr) if attr.belongs_to?
 
         query ||= ->(id){ attr.query_model(self, id) }
-        service_klass = CacheServiceFactory.create_for_active_model(attr, query)
+        service_klass = CacheServiceFactory.create_for_active_model(attr, query, registed?(self))
         Cacher.define_cacher_method(attr, attr.primary_key || :id, [service_klass])
 
         if (infos = get_expire_infos(attr, expire_by, foreign_key))
@@ -68,6 +68,13 @@ module ActiveModelCachers
         ActiveSupport::Dependencies.onload(attr.class_name) do
           service_klasses << cache_self
         end
+      end
+
+      @@registraion_mapping = {}
+      def registed?(key)
+        return true if  @@registraion_mapping[key]
+        @@registraion_mapping[key] = true
+        return false
       end
     end
   end

--- a/lib/active_model_cachers/active_record/extension.rb
+++ b/lib/active_model_cachers/active_record/extension.rb
@@ -17,7 +17,7 @@ module ActiveModelCachers
         return cache_belongs_to(attr) if attr.belongs_to?
 
         query ||= ->(id){ attr.query_model(self, id) }
-        service_klass = CacheServiceFactory.create_for_active_model(self, attr, query)
+        service_klass = CacheServiceFactory.create_for_active_model(attr, query)
         Cacher.define_cacher_method(attr, attr.primary_key || :id, [service_klass])
 
         if (infos = get_expire_infos(attr, expire_by, foreign_key))

--- a/lib/active_model_cachers/cache_service.rb
+++ b/lib/active_model_cachers/cache_service.rb
@@ -8,6 +8,7 @@ module ActiveModelCachers
     class << self
       attr_accessor :cache_key
       attr_accessor :query
+      attr_accessor :active_model_klass
 
       def instance(id)
         hash = (RequestStore.store[self] ||= {})

--- a/lib/active_model_cachers/cache_service.rb
+++ b/lib/active_model_cachers/cache_service.rb
@@ -20,19 +20,12 @@ module ActiveModelCachers
 
       @@column_value_cache = ActiveModelCachers::ColumnValueCache.new
       def define_callback_for_cleaning_cache(class_name, column, foreign_key, with_id, on: nil)
-        check = ->(active_record_klass){
-          callbacks_defined = @callbacks_defined
-          callbacks_defined = false if @active_model_klass and @active_model_klass != active_record_klass
-          @callbacks_defined = true
-          @active_model_klass = active_record_klass
-          next callbacks_defined
-        }
+        return if @callbacks_defined
+        @callbacks_defined = true
 
         clean = ->(id){ clean_at(with_id ? id : nil) }
 
         ActiveSupport::Dependencies.onload(class_name) do
-          next if check.call(self)
-
           clean_ids = []
 
           prepend_before_delete do |id, model|

--- a/lib/active_model_cachers/cache_service.rb
+++ b/lib/active_model_cachers/cache_service.rb
@@ -8,7 +8,6 @@ module ActiveModelCachers
     class << self
       attr_accessor :cache_key
       attr_accessor :query
-      attr_accessor :active_model_klass
 
       def instance(id)
         hash = (RequestStore.store[self] ||= {})
@@ -21,12 +20,19 @@ module ActiveModelCachers
 
       @@column_value_cache = ActiveModelCachers::ColumnValueCache.new
       def define_callback_for_cleaning_cache(class_name, column, foreign_key, with_id, on: nil)
-        return if @callbacks_defined
-        @callbacks_defined = true
+        check = ->(active_record_klass){
+          callbacks_defined = @callbacks_defined
+          callbacks_defined = false if @active_model_klass and @active_model_klass != active_record_klass
+          @callbacks_defined = true
+          @active_model_klass = active_record_klass
+          next callbacks_defined
+        }
 
         clean = ->(id){ clean_at(with_id ? id : nil) }
 
         ActiveSupport::Dependencies.onload(class_name) do
+          next if check.call(class_name)
+
           clean_ids = []
 
           prepend_before_delete do |id, model|

--- a/lib/active_model_cachers/cache_service.rb
+++ b/lib/active_model_cachers/cache_service.rb
@@ -31,7 +31,7 @@ module ActiveModelCachers
         clean = ->(id){ clean_at(with_id ? id : nil) }
 
         ActiveSupport::Dependencies.onload(class_name) do
-          next if check.call(class_name)
+          next if check.call(self)
 
           clean_ids = []
 

--- a/lib/active_model_cachers/cache_service_factory.rb
+++ b/lib/active_model_cachers/cache_service_factory.rb
@@ -22,7 +22,6 @@ module ActiveModelCachers
           klass.cache_key = cache_key
           klass.query = query
           klass.instance_variable_set(:@callbacks_defined, false) # to remove warning: instance variable @callbacks_defined not initialized
-          klass.instance_variable_set(:@active_model_klass, nil) # to remove warning: instance variable @active_model_klass not initialized
           next klass
         }[]
       end

--- a/lib/active_model_cachers/cache_service_factory.rb
+++ b/lib/active_model_cachers/cache_service_factory.rb
@@ -12,11 +12,8 @@ module ActiveModelCachers
         return (@key_class_mapping[get_cache_key(attr)] != nil)
       end
 
-      def create_for_active_model(attr, query, current_klass)
-        class_name, _ = attr.extract_class_and_column
-        cache_key = get_cache_key(attr)
-        clean_klass_cache_if_reloaded!(cache_key, current_klass) if current_klass.name == class_name.to_s
-        return create(cache_key, query)
+      def create_for_active_model(attr, query)
+        create(get_cache_key(attr), query)
       end
 
       def create(cache_key, query)
@@ -27,6 +24,12 @@ module ActiveModelCachers
           klass.instance_variable_set(:@callbacks_defined, false) # to remove warning: instance variable @callbacks_defined not initialized
           next klass
         }[]
+      end
+
+      def set_klass_to_mapping(attr, current_klass)
+        cache_key = get_cache_key(attr)
+        clean_klass_cache_if_reloaded!(cache_key, current_klass)
+        @cache_key_klass_mapping[cache_key] = current_klass
       end
 
       private

--- a/lib/active_model_cachers/cache_service_factory.rb
+++ b/lib/active_model_cachers/cache_service_factory.rb
@@ -28,8 +28,10 @@ module ActiveModelCachers
 
       def set_klass_to_mapping(attr, current_klass)
         cache_key = get_cache_key(attr)
-        clean_klass_cache_if_reloaded!(cache_key, current_klass)
+        reflect = attr.klass.reflect_on_association(:posts)
+        changed = clean_klass_cache_if_reloaded!(cache_key, current_klass, attr)
         @cache_key_klass_mapping[cache_key] = current_klass
+        return changed
       end
 
       private
@@ -42,9 +44,11 @@ module ActiveModelCachers
         return "active_model_cachers_#{class_name}"
       end
 
-      def clean_klass_cache_if_reloaded!(cache_key, current_klass)
+      def clean_klass_cache_if_reloaded!(cache_key, current_klass, attr)
         origin_klass, @cache_key_klass_mapping[cache_key] = @cache_key_klass_mapping[cache_key], current_klass
-        @key_class_mapping[cache_key] = nil if origin_klass and origin_klass != current_klass # when code reloaded in development.
+        return false if origin_klass == nil or origin_klass == current_klass # when code reloaded in development.
+        @key_class_mapping[cache_key] = nil
+        return true
       end
     end
   end

--- a/lib/active_model_cachers/cache_service_factory.rb
+++ b/lib/active_model_cachers/cache_service_factory.rb
@@ -11,17 +11,22 @@ module ActiveModelCachers
         return (@key_class_mapping[get_cache_key(attr)] != nil)
       end
 
-      def create_for_active_model(attr, query)
+      def create_for_active_model(active_model_klass, attr, query)
         cache_key = get_cache_key(attr)
-        service_klass = create(cache_key, query)
+        service_klass = create(cache_key, active_model_klass, query)
+        if service_klass.active_model_klass != active_model_klass
+          @key_class_mapping[cache_key] = nil
+          return create_for_active_model(active_model_klass, attr, query)
+        end
         return service_klass
       end
 
-      def create(cache_key, query)
+      def create(cache_key, active_model_klass, query)
         @key_class_mapping[cache_key] ||= ->{
           klass = Class.new(CacheService)
           klass.cache_key = cache_key
           klass.query = query
+          klass.active_model_klass = active_model_klass
           klass.instance_variable_set(:@callbacks_defined, false) # to remove warning: instance variable @callbacks_defined not initialized
           next klass
         }[]

--- a/lib/active_model_cachers/cache_service_factory.rb
+++ b/lib/active_model_cachers/cache_service_factory.rb
@@ -11,11 +11,12 @@ module ActiveModelCachers
         return (@key_class_mapping[get_cache_key(attr)] != nil)
       end
 
-      def create_for_active_model(attr, query)
-        create(get_cache_key(attr), query)
+      def create_for_active_model(attr, query, recreate)
+        create(get_cache_key(attr), query, recreate)
       end
 
-      def create(cache_key, query)
+      def create(cache_key, query, recreate)
+        @key_class_mapping[cache_key] = nil if recreate
         @key_class_mapping[cache_key] ||= ->{
           klass = Class.new(CacheService)
           klass.cache_key = cache_key
@@ -24,9 +25,6 @@ module ActiveModelCachers
           klass.instance_variable_set(:@active_model_klass, nil) # to remove warning: instance variable @active_model_klass not initialized
           next klass
         }[]
-
-        @key_class_mapping[cache_key].query = query
-        @key_class_mapping[cache_key]
       end
 
       private

--- a/lib/active_model_cachers/cache_service_factory.rb
+++ b/lib/active_model_cachers/cache_service_factory.rb
@@ -5,18 +5,21 @@ require 'active_model_cachers/cache_service'
 module ActiveModelCachers
   class CacheServiceFactory
     @key_class_mapping = {}
+    @cache_key_klass_mapping = {}
 
     class << self
       def has_cacher?(attr)
         return (@key_class_mapping[get_cache_key(attr)] != nil)
       end
 
-      def create_for_active_model(attr, query, recreate)
-        create(get_cache_key(attr), query, recreate)
+      def create_for_active_model(attr, query, current_klass)
+        class_name, _ = attr.extract_class_and_column
+        cache_key = get_cache_key(attr)
+        clean_klass_cache_after_reloaded!(cache_key, current_klass) if current_klass.name == class_name.to_s
+        return create(cache_key, query)
       end
 
-      def create(cache_key, query, recreate)
-        @key_class_mapping[cache_key] = nil if recreate
+      def create(cache_key, query)
         @key_class_mapping[cache_key] ||= ->{
           klass = Class.new(CacheService)
           klass.cache_key = cache_key
@@ -29,11 +32,16 @@ module ActiveModelCachers
       private
 
       def get_cache_key(attr)
-        class_name, column = (attr.single_association? ? [attr.class_name, nil] : [attr.klass, attr.column])
+        class_name, column = attr.extract_class_and_column
         return "active_model_cachers_#{class_name}_at_#{column}" if column
         foreign_key = attr.foreign_key(reverse: true)
         return "active_model_cachers_#{class_name}_by_#{foreign_key}" if foreign_key and foreign_key.to_s != 'id'
         return "active_model_cachers_#{class_name}"
+      end
+
+      def clean_klass_cache_after_reloaded!(cache_key, current_klass)
+        origin_klass, @cache_key_klass_mapping[cache_key] = @cache_key_klass_mapping[cache_key], current_klass
+        @key_class_mapping[cache_key] = nil if origin_klass and origin_klass != current_klass # when code reloaded in development.
       end
     end
   end

--- a/lib/active_model_cachers/cache_service_factory.rb
+++ b/lib/active_model_cachers/cache_service_factory.rb
@@ -15,7 +15,7 @@ module ActiveModelCachers
       def create_for_active_model(attr, query, current_klass)
         class_name, _ = attr.extract_class_and_column
         cache_key = get_cache_key(attr)
-        clean_klass_cache_after_reloaded!(cache_key, current_klass) if current_klass.name == class_name.to_s
+        clean_klass_cache_if_reloaded!(cache_key, current_klass) if current_klass.name == class_name.to_s
         return create(cache_key, query)
       end
 
@@ -39,7 +39,7 @@ module ActiveModelCachers
         return "active_model_cachers_#{class_name}"
       end
 
-      def clean_klass_cache_after_reloaded!(cache_key, current_klass)
+      def clean_klass_cache_if_reloaded!(cache_key, current_klass)
         origin_klass, @cache_key_klass_mapping[cache_key] = @cache_key_klass_mapping[cache_key], current_klass
         @key_class_mapping[cache_key] = nil if origin_klass and origin_klass != current_klass # when code reloaded in development.
       end

--- a/lib/active_model_cachers/cache_service_factory.rb
+++ b/lib/active_model_cachers/cache_service_factory.rb
@@ -24,6 +24,9 @@ module ActiveModelCachers
           klass.instance_variable_set(:@active_model_klass, nil) # to remove warning: instance variable @active_model_klass not initialized
           next klass
         }[]
+
+        @key_class_mapping[cache_key].query = query
+        @key_class_mapping[cache_key]
       end
 
       private

--- a/lib/active_model_cachers/cache_service_factory.rb
+++ b/lib/active_model_cachers/cache_service_factory.rb
@@ -11,23 +11,17 @@ module ActiveModelCachers
         return (@key_class_mapping[get_cache_key(attr)] != nil)
       end
 
-      def create_for_active_model(active_model_klass, attr, query)
-        cache_key = get_cache_key(attr)
-        service_klass = create(cache_key, active_model_klass, query)
-        if service_klass.active_model_klass != active_model_klass
-          @key_class_mapping[cache_key] = nil
-          return create_for_active_model(active_model_klass, attr, query)
-        end
-        return service_klass
+      def create_for_active_model(attr, query)
+        create(get_cache_key(attr), query)
       end
 
-      def create(cache_key, active_model_klass, query)
+      def create(cache_key, query)
         @key_class_mapping[cache_key] ||= ->{
           klass = Class.new(CacheService)
           klass.cache_key = cache_key
           klass.query = query
-          klass.active_model_klass = active_model_klass
           klass.instance_variable_set(:@callbacks_defined, false) # to remove warning: instance variable @callbacks_defined not initialized
+          klass.instance_variable_set(:@active_model_klass, nil) # to remove warning: instance variable @active_model_klass not initialized
           next klass
         }[]
       end

--- a/lib/active_model_cachers/hook/dependencies.rb
+++ b/lib/active_model_cachers/hook/dependencies.rb
@@ -3,12 +3,12 @@ require 'active_support/dependencies'
 
 module ActiveModelCachers::Hook
   module Depdenencies
-    def onload(const_name, &block)
+    def onload(const_name, times: 1, &block)
       const = const_name if not const_name.is_a?(String)
       if const or Module.const_defined?(const_name)
         (const || const_name.constantize).instance_exec(&block)
       else
-        load_hooks[const_name].push(block)
+        load_hooks[const_name].push(block: block, times: times)
       end
     end
 
@@ -17,7 +17,19 @@ module ActiveModelCachers::Hook
     end
 
     def new_constants_in(*)
-      new_constants = super.each{|s| load_hooks[s].each{|hook| s.constantize.instance_exec(&hook) } }
+      new_constants = super.each do |const_name|
+        hooks = load_hooks[const_name]
+        need_compact = false
+        hooks.each_with_index do |hook, idx|
+          if (hook[:times] -= 1) < 0
+            hooks[idx] = nil
+            need_compact = true
+            next
+          end
+          const_name.constantize.instance_exec(&hook[:block])
+        end
+        hooks.compact! if need_compact
+      end
       return new_constants
     end
   end

--- a/test/code_reloading_test.rb
+++ b/test/code_reloading_test.rb
@@ -5,7 +5,7 @@ class CodeReloadingTest < BaseTest
   def test_self
     profile1 = Profile.find_by(token: 'tt9wav')
 
-    reload_models(:Profile) do
+    reload_models(Profile) do
       profile2 = Profile.find_by(token: 'tt9wav')
 
       assert_queries(1){ assert_equal 10, Profile.cacher.find_by(token: 'tt9wav').point }
@@ -18,7 +18,7 @@ class CodeReloadingTest < BaseTest
   def test_association
     posts1 = User.first.posts
 
-    reload_models(:User, :Post) do
+    reload_models(User, Post) do
       posts2 = User.first.posts
 
       assert_queries(1){ assert_equal 3, User.cacher_at(1).posts.size }

--- a/test/code_reloading_test.rb
+++ b/test/code_reloading_test.rb
@@ -5,66 +5,26 @@ class CodeReloadingTest < BaseTest
   def test_self
     profile1 = Profile.find_by(token: 'tt9wav')
 
-    origin_profile_klass = Profile
-    origin_cache = ActiveSupport::Dependencies::Reference
-    origin_loaded = ActiveSupport::Dependencies.loaded
+    reload_models(:Profile) do
+      profile2 = Profile.find_by(token: 'tt9wav')
 
-    ActiveSupport::Dependencies.loaded = []
-    ActiveSupport::Dependencies.send(:remove_const, :Reference)
-    ActiveSupport::Dependencies.const_set(:Reference, ActiveSupport::Dependencies::ClassCache.new)
-    Object.send(:remove_const, :Profile)
-
-    profile2 = Profile.find_by(token: 'tt9wav')
-
-    assert_queries(1){ assert_equal 10, Profile.cacher.find_by(token: 'tt9wav').point }
-    assert_queries(0){ assert_equal 10, Profile.cacher.find_by(token: 'tt9wav').point }
-    assert_cache('active_model_cachers_Profile_by_token_tt9wav' => profile2)
-    refute_equal(profile1, profile2)
-  ensure
-    if origin_cache
-      ActiveSupport::Dependencies.send(:remove_const, :Reference)
-      ActiveSupport::Dependencies.const_set(:Reference, origin_cache)
-    end
-    ActiveSupport::Dependencies.loaded = origin_loaded if origin_loaded
-    if origin_profile_klass
-      Object.send(:remove_const, :Profile)
-      Object.send(:const_set, :Profile, origin_profile_klass)
+      assert_queries(1){ assert_equal 10, Profile.cacher.find_by(token: 'tt9wav').point }
+      assert_queries(0){ assert_equal 10, Profile.cacher.find_by(token: 'tt9wav').point }
+      assert_cache('active_model_cachers_Profile_by_token_tt9wav' => profile2)
+      refute_equal(profile1, profile2)
     end
   end
 
   def test_association
     posts1 = User.first.posts
-    origin_user_klass = User
-    origin_post_klass = Post
-    origin_cache = ActiveSupport::Dependencies::Reference
-    origin_loaded = ActiveSupport::Dependencies.loaded
 
-    ActiveSupport::Dependencies.loaded = []
-    ActiveSupport::Dependencies.send(:remove_const, :Reference)
-    ActiveSupport::Dependencies.const_set(:Reference, ActiveSupport::Dependencies::ClassCache.new)
-    Object.send(:remove_const, :User)
-    Object.send(:remove_const, :Post)
+    reload_models(:User, :Post) do
+      posts2 = User.first.posts
 
-    posts2 = User.first.posts
-
-    assert_queries(1){ assert_equal 3, User.cacher_at(1).posts.size }
-    assert_queries(0){ assert_equal 3, User.cacher_at(1).posts.size }
-    assert_cache('active_model_cachers_User_at_posts_1' => posts2)
-    refute_equal(posts1, posts2)
-  ensure
-    if origin_cache
-      ActiveSupport::Dependencies.send(:remove_const, :Reference)
-      ActiveSupport::Dependencies.const_set(:Reference, origin_cache)
-    end
-    ActiveSupport::Dependencies.loaded = origin_loaded if origin_loaded
-    if origin_user_klass
-      Object.send(:remove_const, :User)
-      Object.send(:const_set, :User, origin_user_klass)
-    end
-
-    if origin_post_klass
-      Object.send(:remove_const, :Post)
-      Object.send(:const_set, :Post, origin_post_klass)
+      assert_queries(1){ assert_equal 3, User.cacher_at(1).posts.size }
+      assert_queries(0){ assert_equal 3, User.cacher_at(1).posts.size }
+      assert_cache('active_model_cachers_User_at_posts_1' => posts2)
+      refute_equal(posts1, posts2)
     end
   end
 end

--- a/test/code_reloading_test.rb
+++ b/test/code_reloading_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'base_test'
+
+class CodeReloadingTest < BaseTest
+  def test_basic_usage
+    profile = User.find_by(name: 'John2').profile
+
+    origin_profile = Profile
+    Object.send(:remove_const, :Profile)
+    load 'lib/models/profile.rb'
+
+    assert_queries(1){ assert_equal 10, Profile.cacher.find_by(token: 'tt9wav').point }
+    assert_queries(0){ assert_equal 10, Profile.cacher.find_by(token: 'tt9wav').point }
+    assert_cache('active_model_cachers_Profile_by_token_tt9wav' => profile)
+
+  ensure
+    Object.send(:const_set, :Profile, origin_profile) if origin_profile
+  end
+end

--- a/test/code_reloading_test.rb
+++ b/test/code_reloading_test.rb
@@ -16,10 +16,10 @@ class CodeReloadingTest < BaseTest
   end
 
   def test_association
-    posts1 = User.first.posts
+    posts1 = User.first.posts.to_a
 
     reload_models(User, Post) do
-      posts2 = User.first.posts
+      posts2 = User.first.posts.to_a
 
       assert_queries(1){ assert_equal 3, User.cacher_at(1).posts.size }
       assert_queries(0){ assert_equal 3, User.cacher_at(1).posts.size }

--- a/test/code_reloading_test.rb
+++ b/test/code_reloading_test.rb
@@ -2,7 +2,7 @@
 require 'base_test'
 
 class CodeReloadingTest < BaseTest
-  def test_basic_usage
+  def test_self
     profile1 = Profile.find_by(token: 'tt9wav')
 
     origin_profile_klass = Profile
@@ -19,6 +19,26 @@ class CodeReloadingTest < BaseTest
     if origin_profile_klass
       Object.send(:remove_const, :Profile)
       Object.send(:const_set, :Profile, origin_profile_klass)
+    end
+  end
+
+  def test_association
+    posts1 = User.first.posts
+
+    origin_post_klass = Post
+    Object.send(:remove_const, :Post)
+    load 'lib/models/post.rb'
+
+    posts2 = User.first.posts
+
+    assert_queries(1){ assert_equal 3, User.cacher_at(1).posts.size }
+    assert_queries(0){ assert_equal 3, User.cacher_at(1).posts.size }
+    assert_cache('active_model_cachers_User_at_posts_1' => posts2)
+    refute_equal(posts1, posts2)
+  ensure
+    if origin_post_klass
+      Object.send(:remove_const, :Post)
+      Object.send(:const_set, :Post, origin_post_klass)
     end
   end
 end

--- a/test/code_reloading_test.rb
+++ b/test/code_reloading_test.rb
@@ -3,17 +3,22 @@ require 'base_test'
 
 class CodeReloadingTest < BaseTest
   def test_basic_usage
-    profile = User.find_by(name: 'John2').profile
+    profile1 = Profile.find_by(token: 'tt9wav')
 
-    origin_profile = Profile
+    origin_profile_klass = Profile
     Object.send(:remove_const, :Profile)
     load 'lib/models/profile.rb'
 
+    profile2 = Profile.find_by(token: 'tt9wav')
+
     assert_queries(1){ assert_equal 10, Profile.cacher.find_by(token: 'tt9wav').point }
     assert_queries(0){ assert_equal 10, Profile.cacher.find_by(token: 'tt9wav').point }
-    assert_cache('active_model_cachers_Profile_by_token_tt9wav' => profile)
-
+    assert_cache('active_model_cachers_Profile_by_token_tt9wav' => profile2)
+    refute_equal(profile1, profile2)
   ensure
-    Object.send(:const_set, :Profile, origin_profile) if origin_profile
+    if origin_profile_klass
+      Object.send(:remove_const, :Profile)
+      Object.send(:const_set, :Profile, origin_profile_klass)
+    end
   end
 end

--- a/test/lib/models/shared_cache/profile.rb
+++ b/test/lib/models/shared_cache/profile.rb
@@ -2,5 +2,6 @@
 class SharedCache::Profile < ActiveRecord::Base
   belongs_to :user, class_name: 'SharedCache::User'
 
+  cache_self
   cache_self by: :user_id
 end

--- a/test/shared_cache_test.rb
+++ b/test/shared_cache_test.rb
@@ -9,7 +9,7 @@ class SharedCacheTest < BaseTest
     assert_queries(0){ assert_equal 19, user.cacher.profile.point }
     assert_cache('active_model_cachers_SharedCache::Profile_by_user_id_1' => user.profile)
 
-    assert_cache_queries(1) do
+    assert_cache_queries(2) do # Delete cache at self and at self_by_user_id
       assert_queries(1){ user.profile.update_attributes(point: 12) }
     end
     assert_cache({})

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,14 +42,14 @@ def assert_cache_queries(expected_count, &block)
 end
 
 def reload_models(*klasses) # EX: klasses = [:User, :Post]
+  origin_klasses = klasses.map{|class_name| [class_name, Object.const_get(class_name)] }.to_h
+  klasses.each{|s| Object.send(:remove_const, s) }
+
   origin_cache = ActiveSupport::Dependencies::Reference
   origin_loaded = ActiveSupport::Dependencies.loaded
   ActiveSupport::Dependencies.loaded = []
   ActiveSupport::Dependencies.send(:remove_const, :Reference)
   ActiveSupport::Dependencies.const_set(:Reference, ActiveSupport::Dependencies::ClassCache.new)
-
-  origin_klasses = klasses.map{|class_name| [class_name, Object.const_get(class_name)] }.to_h
-  klasses.each{|s| Object.send(:remove_const, s) }
 
   yield
 ensure

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,9 +41,9 @@ def assert_cache_queries(expected_count, &block)
   assert_queries(expected_count, 'cache.active_record', &block)
 end
 
-def reload_models(*klasses) # EX: klasses = [:User, :Post]
-  origin_klasses = klasses.map{|class_name| [class_name, Object.const_get(class_name)] }.to_h
-  klasses.each{|s| Object.send(:remove_const, s) }
+def reload_models(*klasses) # EX: klasses = [User, Post]
+  origin_klasses = klasses.map{|klass| [klass.name.to_sym, klass] }.to_h
+  origin_klasses.each{|class_name, _| Object.send(:remove_const, class_name) }
 
   origin_cache = ActiveSupport::Dependencies::Reference
   origin_loaded = ActiveSupport::Dependencies.loaded


### PR DESCRIPTION
In development, any changes will cause the file to be reloaded.
It will cause the class constant being changed.
```rb
origin_id = User.__id__ 

# reload user.rb

origin_id == User.__id__ 
# => false
```

The cache services are cached by cache_key(see https://github.com/khiav223577/active_model_cachers/pull/35), therefore doesn't aware that origin `User` constant doesn't exist anymore. It will try to find model by using old `User` constant, then raising `User cant be referred`.

This PR fixes the issue by maintaining a mapping of `cache_key` and `model class`. Using the mapping to check if it should create new cache service or not.