### PR TITLE
Fix: Eager-loaded models will not register `after_commit` callback

### DIFF
--- a/lib/active_model_cachers/active_record/extension.rb
+++ b/lib/active_model_cachers/active_record/extension.rb
@@ -85,15 +85,16 @@ module ActiveModelCachers
         end
       end
 
-      @@global_callbacks = GlobalCallbacks.new
+      @global_callbacks = GlobalCallbacks.new
       def self.global_callbacks
-        @@global_callbacks
+        @global_callbacks
       end
 
       def self.extended(base)
+        global_callbacks = @global_callbacks
         base.instance_exec do
-          after_commit ->{ @@global_callbacks.after_commit.exec(self, self.class) }
-          after_touch ->{ @@global_callbacks.after_touch.exec(self, self.class) }
+          after_commit ->{ global_callbacks.after_commit.exec(self, self.class) }
+          after_touch ->{ global_callbacks.after_touch.exec(self, self.class) }
         end
       end
     end

--- a/lib/active_model_cachers/active_record/extension.rb
+++ b/lib/active_model_cachers/active_record/extension.rb
@@ -85,7 +85,6 @@ module ActiveModelCachers
         end
       end
 
-
       @@global_callbacks = GlobalCallbacks.new
       def self.global_callbacks
         @@global_callbacks

--- a/lib/active_model_cachers/active_record/extension.rb
+++ b/lib/active_model_cachers/active_record/extension.rb
@@ -93,8 +93,8 @@ module ActiveModelCachers
 
       def self.extended(base)
         base.instance_exec do
-          # after_commit ->{ @@callbacks.exec_after_commit(self) }
-          after_touch ->{ @@global_callbacks.after_touch.exec(self) }
+          after_commit ->{ @@global_callbacks.after_commit.exec(self, self.class) }
+          after_touch ->{ @@global_callbacks.after_touch.exec(self, self.class) }
         end
       end
     end

--- a/lib/active_model_cachers/active_record/extension.rb
+++ b/lib/active_model_cachers/active_record/extension.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'active_model_cachers/active_record/global_callbacks'
 require 'active_model_cachers/active_record/attr_model'
 require 'active_model_cachers/active_record/cacher'
 require 'active_model_cachers/hook/dependencies'
@@ -81,6 +82,19 @@ module ActiveModelCachers
         Cacher.define_cacher_method(attr, attr.primary_key, service_klasses)
         ActiveSupport::Dependencies.onload(attr.class_name) do
           service_klasses << cache_self
+        end
+      end
+
+
+      @@global_callbacks = GlobalCallbacks.new
+      def self.global_callbacks
+        @@global_callbacks
+      end
+
+      def self.extended(base)
+        base.instance_exec do
+          # after_commit ->{ @@callbacks.exec_after_commit(self) }
+          after_touch ->{ @@global_callbacks.after_touch.exec(self) }
         end
       end
     end

--- a/lib/active_model_cachers/active_record/global_callbacks.rb
+++ b/lib/active_model_cachers/active_record/global_callbacks.rb
@@ -1,0 +1,29 @@
+module ActiveModelCachers
+  module ActiveRecord
+    class GlobalCallbacks
+      def initialize
+        @type_callbacks = {}
+      end
+
+      def after_touch(class_name = nil, &block)
+        (@type_callbacks[:after_touch] ||= ClassCallbacks.new).tap do |s|
+          s.add_callback(class_name, &block) if class_name
+        end
+      end
+    end
+
+    class ClassCallbacks
+      def initialize
+        @class_callbacks = Hash.new{|h, k| h[k] = [] }
+      end
+
+      def add_callback(class_name, &block)
+        @class_callbacks[class_name] << block
+      end
+
+      def exec(model)
+        @class_callbacks[model.class.name].each{|s| model.instance_exec(&s) }
+      end
+    end
+  end
+end

--- a/lib/active_model_cachers/active_record/global_callbacks.rb
+++ b/lib/active_model_cachers/active_record/global_callbacks.rb
@@ -5,8 +5,34 @@ module ActiveModelCachers
         @type_callbacks = {}
       end
 
+      def pre_before_delete(class_name = nil, &block)
+        define_callbacks(:pre_before_delete, class_name, &block)
+      end
+
+      def before_delete(class_name = nil, &block)
+        define_callbacks(:before_delete, class_name, &block)
+      end
+
+      def after_delete(class_name = nil, &block)
+        define_callbacks(:after_delete, class_name, &block)
+      end
+
+      def on_nullify(class_name = nil, &block)
+        define_callbacks(:on_nullify, class_name, &block)
+      end
+
+      def after_commit(class_name = nil, &block)
+        define_callbacks(:after_commit, class_name, &block)
+      end
+
       def after_touch(class_name = nil, &block)
-        (@type_callbacks[:after_touch] ||= ClassCallbacks.new).tap do |s|
+        define_callbacks(:after_touch, class_name, &block)
+      end
+
+      private
+
+      def define_callbacks(type, class_name, &block)
+        (@type_callbacks[type] ||= ClassCallbacks.new).tap do |s|
           s.add_callback(class_name, &block) if class_name
         end
       end
@@ -17,12 +43,16 @@ module ActiveModelCachers
         @class_callbacks = Hash.new{|h, k| h[k] = [] }
       end
 
-      def add_callback(class_name, &block)
-        @class_callbacks[class_name] << block
+      def callbacks_at(class_name)
+        @class_callbacks[class_name]
       end
 
-      def exec(model)
-        @class_callbacks[model.class.name].each{|s| model.instance_exec(&s) }
+      def add_callback(class_name, &block)
+        callbacks_at(class_name) << block
+      end
+
+      def exec(scope, klass, *args)
+        callbacks_at(klass.name).each{|s| scope.instance_exec(*args, &s) }
       end
     end
   end

--- a/lib/active_model_cachers/active_record/patch_rails_3.rb
+++ b/lib/active_model_cachers/active_record/patch_rails_3.rb
@@ -6,23 +6,6 @@ module ActiveModelCachers
       def find_by(*args)
         where(*args).order('').first
       end
-
-      # after_commit in Rails 3 cannot specify multiple :on
-      # EX:
-      #   after_commit ->{ ... }, on: [:create, :destroy]
-      #
-      # Should rewrite it as:
-      #   after_commit ->{ ... }, on: :create
-      #   after_commit ->{ ... }, on: :destroy
-
-      def after_commit(*args, &block) # mass-assign protected attributes `id` In Rails 3
-        if args.last.is_a?(Hash)
-          if (on = args.last[:on]).is_a?(Array)
-            return on.each{|s| after_commit(*[*args[0...-1], { **args[-1], on: s }], &block) }
-          end
-        end
-        super
-      end
     end
   end
 end

--- a/lib/active_model_cachers/active_record/patch_rails_3.rb
+++ b/lib/active_model_cachers/active_record/patch_rails_3.rb
@@ -11,6 +11,16 @@ module ActiveModelCachers
 end
 
 module ActiveRecord
+  module Transactions
+    if not method_defined?(:transaction_include_any_action?)
+      def transaction_include_any_action?(*args)
+        transaction_include_action?(*args)
+      end
+    end
+  end
+end
+
+module ActiveRecord
   module Associations
     # = Active Record Associations
     #

--- a/lib/active_model_cachers/active_record/patch_rails_3.rb
+++ b/lib/active_model_cachers/active_record/patch_rails_3.rb
@@ -13,8 +13,8 @@ end
 module ActiveRecord
   module Transactions
     if not method_defined?(:transaction_include_any_action?)
-      def transaction_include_any_action?(*args)
-        transaction_include_action?(*args)
+      def transaction_include_any_action?(fire_on)
+        fire_on.any?{|s| transaction_include_action?(s) }
       end
     end
   end

--- a/lib/active_model_cachers/cache_service.rb
+++ b/lib/active_model_cachers/cache_service.rb
@@ -47,8 +47,10 @@ module ActiveModelCachers
             changed = column ? previous_changes.key?(column) : previous_changes.present?
             clean.call(send(foreign_key)) if changed || destroyed?
           }, on: on
+        end
 
-          after_touch ->{ clean.call(send(foreign_key)) }
+        ActiveRecord::Extension.global_callbacks.instance_exec do
+          after_touch(class_name){ clean.call(send(foreign_key)) }
         end
       end
     end

--- a/lib/active_model_cachers/cache_service.rb
+++ b/lib/active_model_cachers/cache_service.rb
@@ -25,12 +25,12 @@ module ActiveModelCachers
 
         clean = ->(id){ clean_at(with_id ? id : nil) }
 
-        ActiveSupport::Dependencies.onload(class_name) do
-          on_nullify(column){|ids| ids.each{|s| clean.call(s) }}
-        end
-
         ActiveRecord::Extension.global_callbacks.instance_exec do
           clean_ids = []
+
+          on_nullify(class_name) do |nullified_column, get_ids|
+            get_ids.call.each{|s| clean.call(s) } if nullified_column == column
+          end
 
           after_touch(class_name) do
             clean.call(send(foreign_key))

--- a/lib/active_model_cachers/cache_service.rb
+++ b/lib/active_model_cachers/cache_service.rb
@@ -26,31 +26,33 @@ module ActiveModelCachers
         clean = ->(id){ clean_at(with_id ? id : nil) }
 
         ActiveSupport::Dependencies.onload(class_name) do
+          on_nullify(column){|ids| ids.each{|s| clean.call(s) }}
+        end
+
+        ActiveRecord::Extension.global_callbacks.instance_exec do
           clean_ids = []
 
-          prepend_before_delete do |id, model|
+          after_touch(class_name) do
+            clean.call(send(foreign_key))
+          end
+
+          after_commit(class_name) do # TODO: on
+            changed = column ? previous_changes.key?(column) : previous_changes.present?
+            clean.call(send(foreign_key)) if changed || destroyed?
+          end
+
+          pre_before_delete(class_name) do |id, model|
             clean_ids << @@column_value_cache.add(self, class_name, id, foreign_key, model)
           end
 
-          before_delete do |_, model|
+          before_delete(class_name) do |_, model|
             clean_ids.each{|s| clean.call(s.call) }
             clean_ids = []
           end
 
-          after_delete do
+          after_delete(class_name) do
             @@column_value_cache.clean_cache
           end
-
-          on_nullify(column){|ids| ids.each{|s| clean.call(s) }}
-
-          after_commit ->{
-            changed = column ? previous_changes.key?(column) : previous_changes.present?
-            clean.call(send(foreign_key)) if changed || destroyed?
-          }, on: on
-        end
-
-        ActiveRecord::Extension.global_callbacks.instance_exec do
-          after_touch(class_name){ clean.call(send(foreign_key)) }
         end
       end
     end

--- a/lib/active_model_cachers/hook/associations.rb
+++ b/lib/active_model_cachers/hook/associations.rb
@@ -27,10 +27,15 @@ module ActiveModelCachers::Hook
 
     private
 
-    def call_hooks
-      return if (hooks = reflection.klass.nullify_hooks_at(reflection.foreign_key)).blank?
-      ids = yield
-      hooks.each{|s| s.call(ids) }
+    def call_hooks(&get_ids)
+      ids = nil
+      get_ids_with_cache = ->{ ids ||= get_ids.call }
+      ActiveModelCachers::ActiveRecord::Extension.global_callbacks.on_nullify.exec(
+        self,
+        reflection.klass,
+        reflection.foreign_key,
+        get_ids_with_cache,
+      )
     end
   end
 end

--- a/lib/active_model_cachers/hook/on_model_delete.rb
+++ b/lib/active_model_cachers/hook/on_model_delete.rb
@@ -21,15 +21,6 @@ module ActiveModelCachers::Hook
         ActiveModelCachers::ActiveRecord::Extension.global_callbacks.after_delete.exec(self, self, id, model)
         return result
       end
-
-      def nullify_hooks_at(column)
-        @nullify_hooks ||= Hash.new{|h, k| h[k] = [] }
-        return @nullify_hooks[column]
-      end
-
-      def on_nullify(column, &callback)
-        nullify_hooks_at(column) << callback
-      end
     end
   end
 end

--- a/lib/active_model_cachers/hook/on_model_delete.rb
+++ b/lib/active_model_cachers/hook/on_model_delete.rb
@@ -12,30 +12,13 @@ module ActiveModelCachers::Hook
     end
 
     module ClassMethods
-      def prepend_before_delete(&callback)
-        before_delete_hooks.unshift(callback)
-      end
-
-      def before_delete(&callback)
-        before_delete_hooks << callback
-      end
-
-      def after_delete(&callback)
-        after_delete_hooks << callback
-      end
-
-      def before_delete_hooks
-        @before_delete_hooks ||= []
-      end
-
-      def after_delete_hooks
-        @after_delete_hooks ||= []
-      end
-
       def delete(id, model = nil)
-        before_delete_hooks.each{|s| s.call(id, model) }
+        ActiveModelCachers::ActiveRecord::Extension.global_callbacks.pre_before_delete.exec(self, self, id, model)
+        ActiveModelCachers::ActiveRecord::Extension.global_callbacks.before_delete.exec(self, self, id, model)
+
         result = super(id)
-        after_delete_hooks.each{|s| s.call(id, model) }
+
+        ActiveModelCachers::ActiveRecord::Extension.global_callbacks.after_delete.exec(self, self, id, model)
         return result
       end
 

--- a/test/cache_self_test.rb
+++ b/test/cache_self_test.rb
@@ -166,7 +166,7 @@ class CacheSelfTest < BaseTest
 
     # make sure Difficulty only have cache_self, and doesn't cache by other models by something like cache_at :difficulty
     assert_equal [:find_by], Difficulty.cacher.class.attributes
-    assert_equal 2, Difficulty.before_delete_hooks.size
+    assert_equal 1, ActiveModelCachers::ActiveRecord::Extension.global_callbacks.before_delete.callbacks_at(Difficulty.name).size
 
     assert_queries(1){ assert_equal 4, Difficulty.cacher.find_by(id: difficulty.id).level }
     assert_queries(0){ assert_equal 4, Difficulty.cacher.find_by(id: difficulty.id).level }

--- a/test/eager_loaded_class_test.rb
+++ b/test/eager_loaded_class_test.rb
@@ -21,4 +21,21 @@ class EagerLoadedTest < BaseTest
   ensure
     user.profile.update_attributes(point: 19)
   end
+
+  def test_update_belongs_to_association
+    user = EagerLoaded::User.find_by(name: 'Pearl')
+    language = user.language
+
+    assert_queries(2){ assert_equal 'zh-tw', EagerLoaded::User.cacher_at(user.id).language.name }
+    assert_queries(0){ assert_equal 'zh-tw', EagerLoaded::User.cacher_at(user.id).language.name }
+    assert_cache('active_model_cachers_EagerLoaded::User_at_language_id_1' => 2, 'active_model_cachers_EagerLoaded::Language_2' => language)
+
+    assert_queries(1){ language.update_attributes(name: 'ko') }
+    assert_cache("active_model_cachers_EagerLoaded::User_at_language_id_1" => 2)
+
+    assert_queries(1){ assert_equal 'ko', EagerLoaded::User.cacher_at(user.id).language.name }
+    assert_cache('active_model_cachers_EagerLoaded::User_at_language_id_1' => 2, 'active_model_cachers_EagerLoaded::Language_2' => language)
+  ensure
+    language.update_attributes(name: 'zh-tw')
+  end
 end

--- a/test/eager_loaded_class_test.rb
+++ b/test/eager_loaded_class_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'base_test'
+
+class EagerLoadedTest < BaseTest
+  def test_update
+    user = EagerLoaded::User.first
+
+    assert_queries(1){ assert_equal 19, user.cacher.profile.point }
+    assert_queries(0){ assert_equal 19, user.cacher.profile.point }
+    assert_cache('active_model_cachers_EagerLoaded::Profile_by_user_id_1' => user.profile)
+
+    assert_cache_queries(2) do # Delete cache at self and at self_by_user_id
+      assert_queries(1){ user.profile.update_attributes(point: 12) }
+    end
+    assert_cache({})
+
+    user = EagerLoaded::User.first
+    assert_queries(1){ assert_equal 12, user.cacher.profile.point }
+    assert_queries(0){ assert_equal 12, user.cacher.profile.point }
+    assert_cache('active_model_cachers_EagerLoaded::Profile_by_user_id_1' => user.profile)
+  ensure
+    user.profile.update_attributes(point: 19)
+  end
+end

--- a/test/lib/models/eager_loaded.rb
+++ b/test/lib/models/eager_loaded.rb
@@ -1,0 +1,5 @@
+module EagerLoaded
+  def self.table_name_prefix
+    'eager_loaded_'
+  end
+end

--- a/test/lib/models/eager_loaded/language.rb
+++ b/test/lib/models/eager_loaded/language.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+class EagerLoaded::Language < ActiveRecord::Base
+  has_many :users, class_name: 'EagerLoaded::User'
+end

--- a/test/lib/models/eager_loaded/profile.rb
+++ b/test/lib/models/eager_loaded/profile.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class EagerLoaded::Profile < ActiveRecord::Base
+  belongs_to :user, class_name: 'EagerLoaded::User'
+
+  cache_self
+  cache_self by: :user_id
+end

--- a/test/lib/models/eager_loaded/user.rb
+++ b/test/lib/models/eager_loaded/user.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class EagerLoaded::User < ActiveRecord::Base
+  has_one :profile, class_name: 'EagerLoaded::Profile'
+
+  cache_at :profile
+end

--- a/test/lib/models/eager_loaded/user.rb
+++ b/test/lib/models/eager_loaded/user.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class EagerLoaded::User < ActiveRecord::Base
   has_one :profile, class_name: 'EagerLoaded::Profile'
+  belongs_to :language, class_name: 'EagerLoaded::Language'
 
   cache_at :profile
+  cache_at :language
 end

--- a/test/lib/seeds.rb
+++ b/test/lib/seeds.rb
@@ -63,8 +63,13 @@ ActiveRecord::Schema.define do
     t.integer :point
   end
 
+  create_table :eager_loaded_languages, :force => true do |t|
+    t.string :name
+  end
+
   create_table :eager_loaded_users, :force => true do |t|
     t.string :name
+    t.integer :language_id
   end
 
   create_table :eager_loaded_profiles, :force => true do |t|
@@ -78,6 +83,7 @@ ActiveSupport::Dependencies.autoload_paths << File.expand_path('../services/', _
 
 require_relative 'models/eager_loaded/user.rb'
 require_relative 'models/eager_loaded/profile.rb'
+require_relative 'models/eager_loaded/language.rb'
 
 languages = Language.create([
   {name: 'en'},
@@ -162,9 +168,15 @@ shared_cache_profiles = SharedCache::Profile.create([
   {user_id: shared_cache_users[0].id, point: 19},
 ])
 
+eager_loaded_languages = EagerLoaded::Language.create([
+  {name: 'en'},
+  {name: 'zh-tw'},
+  {name: 'jp'},
+])
+
 eager_loaded_users = EagerLoaded::User.create([
-  {name: 'Pearl'},
-  {name: 'Khiav'},
+  {:name => 'Pearl', :language => eager_loaded_languages[1]},
+  {:name => 'Khiav', :language => eager_loaded_languages[2]},
 ])
 
 eager_loaded_profiles = EagerLoaded::Profile.create([

--- a/test/lib/seeds.rb
+++ b/test/lib/seeds.rb
@@ -161,3 +161,12 @@ shared_cache_users = SharedCache::User.create([
 shared_cache_profiles = SharedCache::Profile.create([
   {user_id: shared_cache_users[0].id, point: 19},
 ])
+
+eager_loaded_users = EagerLoaded::User.create([
+  {name: 'Pearl'},
+  {name: 'Khiav'},
+])
+
+eager_loaded_profiles = EagerLoaded::Profile.create([
+  {user_id: eager_loaded_users[0].id, point: 19},
+])

--- a/test/lib/seeds.rb
+++ b/test/lib/seeds.rb
@@ -62,10 +62,22 @@ ActiveRecord::Schema.define do
     t.integer :user_id
     t.integer :point
   end
+
+  create_table :eager_loaded_users, :force => true do |t|
+    t.string :name
+  end
+
+  create_table :eager_loaded_profiles, :force => true do |t|
+    t.integer :user_id
+    t.integer :point
+  end
 end
 
 ActiveSupport::Dependencies.autoload_paths << File.expand_path('../models/', __FILE__)
 ActiveSupport::Dependencies.autoload_paths << File.expand_path('../services/', __FILE__)
+
+require_relative 'models/eager_loaded/user.rb'
+require_relative 'models/eager_loaded/profile.rb'
 
 languages = Language.create([
   {name: 'en'},


### PR DESCRIPTION
Rails will eager loading all the models In production, and do not fire `ActiveSupport::Dependencies.onload` events. This causes `after_commit` not being registered.

This PR fixes this issue by register only one `after_commit` in `ActiveRecord::Base`, and maintaining all the callbacks manually in a hash table.