### PR TITLE
Fix: binding problem

### DIFF
--- a/lib/active_model_cachers/active_record/cacher.rb
+++ b/lib/active_model_cachers/active_record/cacher.rb
@@ -78,15 +78,17 @@ module ActiveModelCachers
 
       def exec_by(attr, primary_key, service_klasses, method, data: nil)
         bindings = [@model]
+        reflects = [attr.reflect]
         if @model and attr.association?
           if attr.belongs_to? and method != :clean_cache # no need to load binding when just cleaning cache
             association = @model.association(attr.column)
             bindings << association.load_target if association.loaded?
+            reflects << association.reflection
           end
         end
         data ||= (@model ? @model.send(primary_key) : nil) || @id
         service_klasses.each_with_index do |service_klass, index|
-          data = service_klass.instance(data).send(method, binding: bindings[index], attr: attr)
+          data = service_klass.instance(data).send(method, binding: bindings[index], reflect: reflects[index])
           return if data == nil
         end
         return data

--- a/lib/active_model_cachers/active_record/cacher.rb
+++ b/lib/active_model_cachers/active_record/cacher.rb
@@ -86,7 +86,7 @@ module ActiveModelCachers
         end
         data ||= (@model ? @model.send(primary_key) : nil) || @id
         service_klasses.each_with_index do |service_klass, index|
-          data = service_klass.instance(data).send(method, binding: bindings[index])
+          data = service_klass.instance(data).send(method, binding: bindings[index], attr: attr)
           return if data == nil
         end
         return data

--- a/lib/active_model_cachers/active_record/cacher.rb
+++ b/lib/active_model_cachers/active_record/cacher.rb
@@ -78,12 +78,11 @@ module ActiveModelCachers
 
       def exec_by(attr, primary_key, service_klasses, method, data: nil)
         bindings = [@model]
-        reflects = [attr.reflect]
+        reflects = (attr.belongs_to? ? [] : [attr.reflect])
         if @model and attr.association?
           if attr.belongs_to? and method != :clean_cache # no need to load binding when just cleaning cache
             association = @model.association(attr.column)
             bindings << association.load_target if association.loaded?
-            reflects << association.reflection
           end
         end
         data ||= (@model ? @model.send(primary_key) : nil) || @id

--- a/lib/active_model_cachers/cache_service.rb
+++ b/lib/active_model_cachers/cache_service.rb
@@ -89,7 +89,10 @@ module ActiveModelCachers
     end
 
     def get_query(binding, reflect)
-      self.class.query_mapping[reflect] || self.class.query_mapping.values.first
+      self.class.query_mapping[reflect] || begin
+        puts "Warning: cannot find query. possible reflects: #{self.class.query_mapping.keys}, reflect: #{reflect}"
+        self.class.query_mapping.values.first
+      end
     end
 
     def get_without_cache(binding, attr)

--- a/lib/active_model_cachers/cache_service.rb
+++ b/lib/active_model_cachers/cache_service.rb
@@ -65,17 +65,17 @@ module ActiveModelCachers
       @id = id
     end
 
-    def get(binding: nil, attr: nil)
-      @cached_data ||= fetch_from_cache(binding: binding, attr: attr)
+    def get(binding: nil, reflect: nil)
+      @cached_data ||= fetch_from_cache(binding: binding, reflect: reflect)
       return cache_to_raw_data(@cached_data)
     end
 
-    def peek(binding: nil, attr: nil)
+    def peek(binding: nil, reflect: nil)
       @cached_data ||= get_from_cache
       return cache_to_raw_data(@cached_data)
     end
 
-    def clean_cache(binding: nil, attr: nil)
+    def clean_cache(binding: nil, reflect: nil)
       @cached_data = nil
       Rails.cache.delete(cache_key)
       return nil
@@ -88,8 +88,8 @@ module ActiveModelCachers
       return @id ? "#{key}_#{@id}" : key
     end
 
-    def get_query(binding, attr)
-      self.class.query_mapping[attr] || self.class.query_mapping.values.first
+    def get_query(binding, reflect)
+      self.class.query_mapping[reflect] || self.class.query_mapping.values.first
     end
 
     def get_without_cache(binding, attr)
@@ -115,9 +115,9 @@ module ActiveModelCachers
       ActiveModelCachers.config.store.read(cache_key)
     end
 
-    def fetch_from_cache(binding: nil, attr: nil)
+    def fetch_from_cache(binding: nil, reflect: nil)
       ActiveModelCachers.config.store.fetch(cache_key, expires_in: 30.minutes) do
-        raw_to_cache_data(get_without_cache(binding, attr))
+        raw_to_cache_data(get_without_cache(binding, reflect))
       end
     end
 

--- a/lib/active_model_cachers/cache_service.rb
+++ b/lib/active_model_cachers/cache_service.rb
@@ -7,7 +7,7 @@ module ActiveModelCachers
   class CacheService
     class << self
       attr_accessor :cache_key
-      attr_accessor :query
+      attr_accessor :query_mapping
 
       def instance(id)
         hash = (RequestStore.store[self] ||= {})
@@ -65,17 +65,17 @@ module ActiveModelCachers
       @id = id
     end
 
-    def get(binding: nil)
-      @cached_data ||= fetch_from_cache(binding: binding)
+    def get(binding: nil, attr: nil)
+      @cached_data ||= fetch_from_cache(binding: binding, attr: attr)
       return cache_to_raw_data(@cached_data)
     end
 
-    def peek(binding: nil)
+    def peek(binding: nil, attr: nil)
       @cached_data ||= get_from_cache
       return cache_to_raw_data(@cached_data)
     end
 
-    def clean_cache(binding: nil)
+    def clean_cache(binding: nil, attr: nil)
       @cached_data = nil
       Rails.cache.delete(cache_key)
       return nil
@@ -88,8 +88,12 @@ module ActiveModelCachers
       return @id ? "#{key}_#{@id}" : key
     end
 
-    def get_without_cache(binding)
-      query = self.class.query
+    def get_query(binding, attr)
+      self.class.query_mapping[attr] || self.class.query_mapping.values.first
+    end
+
+    def get_without_cache(binding, attr)
+      query = get_query(binding, attr)
       return binding ? binding.instance_exec(@id, &query) : query.call(@id) if @id and query.parameters.size == 1
       return binding ? binding.instance_exec(&query) : query.call
     end
@@ -111,9 +115,9 @@ module ActiveModelCachers
       ActiveModelCachers.config.store.read(cache_key)
     end
 
-    def fetch_from_cache(binding: nil)
+    def fetch_from_cache(binding: nil, attr: nil)
       ActiveModelCachers.config.store.fetch(cache_key, expires_in: 30.minutes) do
-        raw_to_cache_data(get_without_cache(binding))
+        raw_to_cache_data(get_without_cache(binding, attr))
       end
     end
 

--- a/lib/active_model_cachers/cache_service_factory.rb
+++ b/lib/active_model_cachers/cache_service_factory.rb
@@ -23,7 +23,7 @@ module ActiveModelCachers
           next klass
         }[]
 
-        klass.query_mapping[attr] = query
+        klass.query_mapping[attr.reflect] = query
         return klass
       end
 

--- a/lib/active_model_cachers/cache_service_factory.rb
+++ b/lib/active_model_cachers/cache_service_factory.rb
@@ -13,17 +13,18 @@ module ActiveModelCachers
       end
 
       def create_for_active_model(attr, query)
-        create(get_cache_key(attr), query)
-      end
+        cache_key = get_cache_key(attr)
 
-      def create(cache_key, query)
-        @key_class_mapping[cache_key] ||= ->{
+        klass = @key_class_mapping[cache_key] ||= ->{
           klass = Class.new(CacheService)
           klass.cache_key = cache_key
-          klass.query = query
+          klass.query_mapping = {}
           klass.instance_variable_set(:@callbacks_defined, false) # to remove warning: instance variable @callbacks_defined not initialized
           next klass
         }[]
+
+        klass.query_mapping[attr] = query
+        return klass
       end
 
       def set_klass_to_mapping(attr, current_klass)

--- a/test/lib/seeds.rb
+++ b/test/lib/seeds.rb
@@ -81,8 +81,9 @@ end
 ActiveSupport::Dependencies.autoload_paths << File.expand_path('../models/', __FILE__)
 ActiveSupport::Dependencies.autoload_paths << File.expand_path('../services/', __FILE__)
 
-require_relative 'models/eager_loaded/user.rb'
+# make sure `Profile.cache_self` be executed first, then `User.cache_at :profile`
 require_relative 'models/eager_loaded/profile.rb'
+require_relative 'models/eager_loaded/user.rb'
 # require_relative 'models/eager_loaded/language.rb' # EagerLoaded::Language is auto-loaded in models/eager_loaded/user.rb
 fail 'language should be defined here' if not defined?(EagerLoaded::Language)
 


### PR DESCRIPTION
In this example, the two cacher has same `cache_key` ,and thus they'll share same cache_service.
And in #23, cacher will use loaded model if possible.

They share same service but the strategy to use loaded model is different: `profile` should use `self`, and `user` should use `.profile`. But it doesn't know which one to use.

```rb
class Profile < ActiveRecord::Base
  cache_self
end

class User < ActiveRecord::Base
  cache_at :profile
end
```

This PR fixes it by using a mapping to record all strategies.
https://github.com/khiav223577/active_model_cachers/blob/b076a94fdea0e4fae556c6c22d16bb9cb819cdff/lib/active_model_cachers/cache_service_factory.rb#L26