### PR TITLE
lazily add global callbacks to ActiveRecord::Base

### DIFF
--- a/lib/active_model_cachers/active_record/extension.rb
+++ b/lib/active_model_cachers/active_record/extension.rb
@@ -85,17 +85,20 @@ module ActiveModelCachers
         end
       end
 
-      @global_callbacks = GlobalCallbacks.new
+      @global_callbacks = nil
       def self.global_callbacks
-        @global_callbacks
-      end
-
-      def self.extended(base)
-        global_callbacks = @global_callbacks
-        base.instance_exec do
-          after_commit ->{ global_callbacks.after_commit.exec(self, self.class) }
-          after_touch ->{ global_callbacks.after_touch.exec(self, self.class) }
+        if @global_callbacks == nil
+          global_callbacks = @global_callbacks = GlobalCallbacks.new
+          ::ActiveRecord::Base.instance_exec do
+            after_commit ->{
+              global_callbacks.after_commit.exec(self, self.class)
+            }
+            after_touch ->{
+              global_callbacks.after_touch.exec(self, self.class)
+            }
+          end
         end
+        return @global_callbacks
       end
     end
   end


### PR DESCRIPTION
Hope it will fix #39

### original flow
```
- load gems
  - load `active_model_cachers`
     - register after_commit callback in ActiveRecord::Base
      // => WARNING raised

- setup `config/application`
  - config.active_record.raise_in_transactional_callbacks = true

- load models
```

### new flow
```
- load gems:
  - load `active_model_cachers`

- setup `config/application`
  - config.active_record.raise_in_transactional_callbacks = true

- load models
  - register after_commit callback in ActiveRecord::Base
  // => no WARNING raised
```