### PR TITLE
Drop the support of ruby 2.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.2
+          - 2.3
           - 2.6
           - 2.7
         gemfile:
@@ -38,7 +38,7 @@ jobs:
           - gemfile: 4.2.gemfile
             ruby: 2.7
           - gemfile: 6.0.gemfile
-            ruby: 2.2
+            ruby: 2.3
     env:
       BUNDLE_GEMFILE: "gemfiles/${{ matrix.gemfile }}"
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@ ActiveModelCachers:
 
 - Uses multiple levels of cache ([Multi-level Cache](#multi-level-cache))
 - Does not pollute the original ActiveModel API
-- Supports ActiveRecord 3.2, 4.2, 5.2, 6.0.
 - Has high test coverage
+
+## Supports
+
+- Ruby 2.3 ~ 2.7
+- Rails 3.2, 4.2, 5.0, 5.1, 5.2, 6.0
 
 ## Table of contents
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,11 +34,14 @@ end
 def assert_queries(expected_count, event_key = 'sql.active_record')
   sqls = []
   subscriber = ActiveSupport::Notifications.subscribe(event_key) do |_, _, _, _, payload|
-    sqls << "  ● #{payload[:sql]}" if payload[:sql] !~ /\A(?:BEGIN TRANSACTION|COMMIT TRANSACTION|BEGIN|COMMIT|PRAGMA table_info)\z/i
+    next if payload[:sql].start_with?('PRAGMA table_info')
+    next if payload[:sql] =~ /\A(?:BEGIN TRANSACTION|COMMIT TRANSACTION|BEGIN|COMMIT)\z/i
+
+    sqls << "  ● #{payload[:sql]}"
   end
   yield
   if expected_count != sqls.size # show all sql queries if query count doesn't equal to expected count.
-    assert_equal "expect #{expected_count} queries, but have #{sqls.size}", "\n#{sqls.join("\n").gsub('"', "'")}\n"
+    assert_equal "expect #{expected_count} queries, but have #{sqls.size}", "\n#{sqls.join("\n").tr('"', "'")}\n"
   end
   assert_equal expected_count, sqls.size
 ensure


### PR DESCRIPTION
since we encounter Segmentation fault and have no idea how to fix it

The error messages:

```
Installing Bundler
  /opt/hostedtoolcache/Ruby/2.2.10/x64/bin/gem install bundler -v 1.17.3
  /opt/hostedtoolcache/Ruby/2.2.10/x64/lib/ruby/2.2.0/rubygems/source.rb:192: [BUG] Segmentation fault at 0x00000000000010
  ruby 2.2.10p489 (2018-03-28 revision 63023) [x86_64-linux]
```
